### PR TITLE
Derive debug for Server and ServerCommand

### DIFF
--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -5,6 +5,7 @@ use futures::Future;
 use crate::builder::ServerBuilder;
 use crate::signals::Signal;
 
+#[derive(Debug)]
 pub(crate) enum ServerCommand {
     WorkerDied(usize),
     Pause(oneshot::Sender<()>),
@@ -17,7 +18,7 @@ pub(crate) enum ServerCommand {
     },
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Server(UnboundedSender<ServerCommand>);
 
 impl Server {


### PR DESCRIPTION
If you make a Result<Server, _>, you can't call unwrap_err() on the Result because Server doesn't derive Debug.

This PR derives Debug for Server and ServerCommand.