### PR TITLE
Add ServerCommand::Restart and Command::Restart

### DIFF
--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -287,6 +287,10 @@ impl ServerBuilder {
                 self.accept.send(Command::Resume);
                 let _ = tx.send(());
             }
+            ServerCommand::Restart(tx) => {
+                self.accept.send(Command::Restart);
+                let _ = tx.send(());
+            }
             ServerCommand::Signal(sig) => {
                 // Signals support
                 // Handle `SIGINT`, `SIGTERM`, `SIGQUIT` signals and stop actix system

--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -10,6 +10,7 @@ pub(crate) enum ServerCommand {
     WorkerDied(usize),
     Pause(oneshot::Sender<()>),
     Resume(oneshot::Sender<()>),
+    Restart(oneshot::Sender<()>),
     Signal(Signal),
     /// Whether to try and shut down gracefully
     Stop {
@@ -53,6 +54,13 @@ impl Server {
     pub fn resume(&self) -> impl Future<Item = (), Error = ()> {
         let (tx, rx) = oneshot::channel();
         let _ = self.0.unbounded_send(ServerCommand::Resume(tx));
+        rx.map_err(|_| ())
+    }
+
+    /// Restart server
+    pub fn restart(&self) -> impl Future<Item = (), Error = ()> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.0.unbounded_send(ServerCommand::Restart(tx));
         rx.map_err(|_| ())
     }
 


### PR DESCRIPTION
This PR creates a new `ServerCommand` and corresponding `Command` to restart server workers.

Related to actix/actix-web#280