### PR TITLE
Allow Actix to be started on an external CurrentThread runtime

### DIFF
--- a/actix-rt/src/builder.rs
+++ b/actix-rt/src/builder.rs
@@ -1,11 +1,12 @@
 use std::borrow::Cow;
 use std::io;
 
+use futures::future;
 use futures::future::{lazy, Future};
 use futures::sync::mpsc::unbounded;
 use futures::sync::oneshot::{channel, Receiver};
 
-use tokio_current_thread::CurrentThread;
+use tokio_current_thread::{CurrentThread, Handle};
 use tokio_reactor::Reactor;
 use tokio_timer::clock::Clock;
 use tokio_timer::timer::Timer;
@@ -69,6 +70,13 @@ impl Builder {
         self.create_runtime(|| {})
     }
 
+    /// Create new System that can run asynchronously.
+    ///
+    /// This method panics if it cannot start the system arbiter
+    pub fn build_async(self, executor: Handle) -> AsyncSystemRunner {
+        self.create_async_runtime(executor)
+    }
+
     /// This function will start tokio runtime and will finish once the
     /// `System::stop()` message get called.
     /// Function `f` get called within tokio runtime context.
@@ -77,6 +85,22 @@ impl Builder {
         F: FnOnce() + 'static,
     {
         self.create_runtime(f).run()
+    }
+
+    fn create_async_runtime(self, executor: Handle) -> AsyncSystemRunner
+    {
+        let (stop_tx, stop) = channel();
+        let (sys_sender, sys_receiver) = unbounded();
+
+        let system = System::construct(sys_sender, Arbiter::new_system(), self.stop_on_panic);
+
+        // system arbiter
+        let arb = SystemArbiter::new(stop_tx, sys_receiver);
+
+        // start the system arbiter
+        executor.spawn(arb).expect("could not start system arbiter");
+
+        AsyncSystemRunner { stop, system }
     }
 
     fn create_runtime<F>(self, f: F) -> SystemRunner
@@ -124,6 +148,48 @@ impl Builder {
             self.clock.clone(),
             executor,
         ))
+    }
+}
+
+#[derive(Debug)]
+pub struct AsyncSystemRunner {
+    stop: Receiver<i32>,
+    system: System,
+}
+
+impl AsyncSystemRunner {
+    /// This function will start event loop and returns a future that
+    /// resolves once the `System::stop()` function is called.
+    pub fn run_nonblocking(self) -> Box<Future<Item = (), Error = io::Error> + Send + 'static> {
+        let AsyncSystemRunner { stop, .. } = self;
+
+        // run loop
+        Box::new(future::ok(())
+            .and_then(|_| {
+                Arbiter::run_system();
+                future::ok(())
+            }).
+            and_then(|_| {
+                stop.then(|res| {
+                    match res {
+                        Ok(code) => {
+                            if code != 0 {
+                                Err(io::Error::new(
+                                    io::ErrorKind::Other,
+                                    format!("Non-zero exit code: {}", code),
+                                ))
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+                    }
+                })
+            }).then(|result| {
+                Arbiter::stop_system();
+                result
+            })
+        )
     }
 }
 

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -57,9 +57,9 @@ impl System {
     }
 
     #[allow(clippy::new_ret_no_self)]
-    /// Create new system.
+    /// Create new system using provided CurrentThread Handle.
     ///
-    /// This method panics if it can not create tokio runtime
+    /// This method panics if it can not spawn system arbiter
     pub fn new_async<T: Into<String>>(name: T, executor: Handle) -> AsyncSystemRunner {
         Self::builder().name(name).build_async(executor)
     }

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -2,10 +2,11 @@ use std::cell::RefCell;
 use std::io;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use tokio_current_thread::Handle;
 use futures::sync::mpsc::UnboundedSender;
 
 use crate::arbiter::{Arbiter, SystemCommand};
-use crate::builder::{Builder, SystemRunner};
+use crate::builder::{Builder, SystemRunner, AsyncSystemRunner};
 
 static SYSTEM_COUNT: AtomicUsize = AtomicUsize::new(0);
 
@@ -53,6 +54,14 @@ impl System {
     /// This method panics if it can not create tokio runtime
     pub fn new<T: Into<String>>(name: T) -> SystemRunner {
         Self::builder().name(name).build()
+    }
+
+    #[allow(clippy::new_ret_no_self)]
+    /// Create new system.
+    ///
+    /// This method panics if it can not create tokio runtime
+    pub fn new_async<T: Into<String>>(name: T, executor: Handle) -> AsyncSystemRunner {
+        Self::builder().name(name).build_async(executor)
     }
 
     /// Get current running system.


### PR DESCRIPTION
This PR includes the minimum set of changes to enable running Actix on an external runtime.

Example usage:

```
let rt = tokio_current_thread::CurrentThread.handle();
let system = actix::System::new_async("async system", rt.to_owned());
rt.spawn(system.run_nonblocking().map_err(|e| error!("{}", e)))
  .map_err(|e| error!("Could not start actix async: {}", e))
```