### PR TITLE
Feature uds: Add listen_uds to ServerBuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 * Use new `Service<Request>` trait
 
+* Add UDS listening support to `ServerBuilder`
 
 ## [0.2.4] - 2018-11-21
 


### PR DESCRIPTION
Allows directly passing an Unix Listener instead of a path. Useful
for example when running as a daemon under systemd with the systemd
crate.