### PR TITLE
Add an error message if we receive a non-hostname-based dest

### DIFF
--- a/actix-connect/src/ssl/rustls.rs
+++ b/actix-connect/src/ssl/rustls.rs
@@ -94,7 +94,8 @@ where
     fn call(&mut self, stream: Connection<T, U>) -> Self::Future {
         trace!("SSL Handshake start for: {:?}", stream.host());
         let (io, stream) = stream.replace(());
-        let host = DNSNameRef::try_from_ascii_str(stream.host()).unwrap();
+        let host = DNSNameRef::try_from_ascii_str(stream.host())
+            .expect("rustls currently only handles hostname-based connections. See https://github.com/briansmith/webpki/issues/54");
         ConnectAsyncExt {
             fut: TlsConnector::from(self.connector.clone()).connect(host, io),
             stream: Some(stream),

--- a/actix-connect/tests/test_connect.rs
+++ b/actix-connect/tests/test_connect.rs
@@ -42,6 +42,7 @@ fn test_rustls_string() {
     let con = test::call_service(&mut conn, addr.into());
     assert_eq!(con.peer_addr().unwrap(), srv.addr());
 }
+
 #[test]
 fn test_static_str() {
     let srv = TestServer::with(|| {


### PR DESCRIPTION
Cheap fix for #52. 
This is more helpful than an unwrap and at least points users at the right location.
Upstream issue is https://github.com/briansmith/webpki/issues/54