### PR TITLE
Allow to join the Arbiter

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -6,6 +6,10 @@
 
 * Fix arbiter's thread panic message.
 
+### Added
+
+* Allow to join arbiter's thread. #60
+
 
 ## [0.2.5] - 2019-09-02
 


### PR DESCRIPTION
I had an [issue](https://github.com/actix/actix/issues/296) with actors running into non-default Arbiter, so this is a way to wait for the Arbiter to finish by joining its underlying thread.