### PR TITLE
Migrate actix-server::ssl::nativetls to std futures

### DIFF
--- a/actix-server-config/Cargo.toml
+++ b/actix-server-config/Cargo.toml
@@ -14,24 +14,14 @@ name = "actix_server_config"
 path = "src/lib.rs"
 
 [package.metadata.docs.rs]
-features = ["ssl", "rust-tls"]
+features = ["openssl", "rustls"]
 
 [features]
 default = []
-
-# openssl
-ssl = ["tokio-openssl"]
-
-# rustls
-rust-tls = ["rustls", "tokio-rustls"]
+openssl = ["tokio-openssl"]
+rustls = ["tokio-rustls"]
 
 [dependencies]
-futures = "0.3.1"
 tokio = "0.2.0-alpha.6"
-
-# openssl
 tokio-openssl = { version = "0.4.0-alpha.6", optional = true }
-
-# rustls
-rustls = { version = "0.16.0", optional = true }
 tokio-rustls = { version = "0.12.0-alpha.8", optional = true }

--- a/actix-server-config/src/lib.rs
+++ b/actix-server-config/src/lib.rs
@@ -177,7 +177,7 @@ impl IoStream for TcpStream {
     }
 }
 
-#[cfg(feature = "ssl")]
+#[cfg(feature = "openssl")]
 impl<T: IoStream + Unpin> IoStream for tokio_openssl::SslStream<T> {
     #[inline]
     fn peer_addr(&self) -> Option<net::SocketAddr> {
@@ -200,7 +200,7 @@ impl<T: IoStream + Unpin> IoStream for tokio_openssl::SslStream<T> {
     }
 }
 
-#[cfg(feature = "rust-tls")]
+#[cfg(feature = "rustls")]
 impl<T: IoStream + Unpin> IoStream for tokio_rustls::server::TlsStream<T> {
     #[inline]
     fn peer_addr(&self) -> Option<net::SocketAddr> {

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -23,8 +23,8 @@ path = "src/lib.rs"
 [features]
 default = []
 
-# tls
-tls = ["native-tls"]
+# native-tls
+tls = ["native-tls", "tokio-tls"]
 
 # openssl
 ssl = ["openssl", "tokio-openssl", "actix-server-config/ssl"]
@@ -54,15 +54,16 @@ tokio-net = { version = "0.2.0-alpha.6", features = ["signal"] }
 tokio-timer = "0.3.0-alpha.6"
 
 # unix domain sockets
-mio-uds = { version="0.6.7", optional = true }
+mio-uds = { version = "0.6.7", optional = true }
 #tokio-uds = { version="0.2.5", optional = true }
 
 # native-tls
-native-tls = { version="0.2", optional = true }
+native-tls = { version = "0.2", optional = true }
+tokio-tls = { version = "0.3.0-alpha.6", optional = true }
 
 # openssl
-openssl = { version="0.10", optional = true }
-tokio-openssl = { version="0.4.0-alpha.6", optional = true }
+openssl = { version = "0.10", optional = true }
+tokio-openssl = { version = "0.4.0-alpha.6", optional = true }
 
 # rustls
 rustls = { version = "0.16.0", optional = true }

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 workspace = ".."
 
 [package.metadata.docs.rs]
-features = ["ssl", "tls", "rust-tls", "uds"]
+features = ["nativetls", "openssl", "rustls", "uds"]
 
 [lib]
 name = "actix_server"
@@ -22,15 +22,9 @@ path = "src/lib.rs"
 
 [features]
 default = []
-
-# native-tls
-tls = ["native-tls", "tokio-tls"]
-
-# openssl
-ssl = ["openssl", "tokio-openssl", "actix-server-config/ssl"]
-
-# rustls
-rust-tls = ["rustls", "tokio-rustls", "webpki", "webpki-roots", "actix-server-config/rust-tls"]
+nativetls = ["native-tls", "tokio-tls"]
+openssl = ["open-ssl", "tokio-openssl", "actix-server-config/openssl"]
+rustls = ["rust-tls", "tokio-rustls", "webpki", "webpki-roots", "actix-server-config/rustls"]
 
 # uds
 # uds = ["mio-uds", "tokio-uds", "actix-server-config/uds"]
@@ -57,16 +51,16 @@ tokio-timer = "0.3.0-alpha.6"
 mio-uds = { version = "0.6.7", optional = true }
 #tokio-uds = { version="0.2.5", optional = true }
 
-# native-tls
+# nativetls
 native-tls = { version = "0.2", optional = true }
 tokio-tls = { version = "0.3.0-alpha.6", optional = true }
 
 # openssl
-openssl = { version = "0.10", optional = true }
+open-ssl = { version = "0.10", package = "openssl", optional = true }
 tokio-openssl = { version = "0.4.0-alpha.6", optional = true }
 
 # rustls
-rustls = { version = "0.16.0", optional = true }
+rust-tls = { version = "0.16.0", package = "rustls", optional = true }
 tokio-rustls = { version = "0.12.0-alpha.2", optional = true }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.17", optional = true }

--- a/actix-server/src/ssl/mod.rs
+++ b/actix-server/src/ssl/mod.rs
@@ -11,7 +11,7 @@ pub use self::openssl::OpensslAcceptor;
 #[cfg(feature = "tls")]
 mod nativetls;
 #[cfg(feature = "tls")]
-pub use self::nativetls::{NativeTlsAcceptor, TlsStream};
+pub use self::nativetls::NativeTlsAcceptor;
 
 #[cfg(feature = "rust-tls")]
 mod rustls;

--- a/actix-server/src/ssl/mod.rs
+++ b/actix-server/src/ssl/mod.rs
@@ -3,19 +3,19 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::counter::Counter;
 
-#[cfg(feature = "ssl")]
+#[cfg(feature = "openssl")]
 mod openssl;
-#[cfg(feature = "ssl")]
+#[cfg(feature = "openssl")]
 pub use self::openssl::OpensslAcceptor;
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "nativetls")]
 mod nativetls;
-#[cfg(feature = "tls")]
+#[cfg(feature = "nativetls")]
 pub use self::nativetls::NativeTlsAcceptor;
 
-#[cfg(feature = "rust-tls")]
+#[cfg(feature = "rustls")]
 mod rustls;
-#[cfg(feature = "rust-tls")]
+#[cfg(feature = "rustls")]
 pub use self::rustls::RustlsAcceptor;
 
 /// Sets the maximum per-worker concurrent ssl connection establish process.

--- a/actix-server/src/ssl/nativetls.rs
+++ b/actix-server/src/ssl/nativetls.rs
@@ -1,16 +1,18 @@
+use std::convert::Infallible;
+use std::future::Future;
 use std::io;
 use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use actix_service::{NewService, Service};
-use futures::{future::ok, future::FutureResult, Async, Future, Poll};
-use native_tls::{self, Error, HandshakeError, TlsAcceptor};
+use actix_service::{Service, ServiceFactory};
+use futures::future;
+use native_tls::{Error, HandshakeError, TlsAcceptor, TlsStream};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use crate::counter::{Counter, CounterGuard};
 use crate::ssl::MAX_CONN_COUNTER;
 use crate::{Io, Protocol, ServerConfig};
-use std::pin::Pin;
-use std::task::Context;
 
 /// Support `SSL` connections via native-tls package
 ///
@@ -30,7 +32,7 @@ impl<T: AsyncRead + AsyncWrite, P> NativeTlsAcceptor<T, P> {
     }
 }
 
-impl<T: AsyncRead + AsyncWrite, P> Clone for NativeTlsAcceptor<T, P> {
+impl<T, P> Clone for NativeTlsAcceptor<T, P> {
     fn clone(&self) -> Self {
         Self {
             acceptor: self.acceptor.clone(),
@@ -39,21 +41,21 @@ impl<T: AsyncRead + AsyncWrite, P> Clone for NativeTlsAcceptor<T, P> {
     }
 }
 
-impl<T: AsyncRead + AsyncWrite, P> NewService for NativeTlsAcceptor<T, P> {
+impl<T: AsyncRead + AsyncWrite, P> ServiceFactory for NativeTlsAcceptor<T, P> {
     type Request = Io<T, P>;
-    type Response = Io<TlsStream<T>, P>;
+    type Response = Io<NativeTlsStream<T>, P>;
     type Error = Error;
 
     type Config = ServerConfig;
     type Service = NativeTlsAcceptorService<T, P>;
-    type InitError = ();
-    type Future = FutureResult<Self::Service, Self::InitError>;
+    type InitError = Infallible;
+    type Future = future::Ready<Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, cfg: &ServerConfig) -> Self::Future {
         cfg.set_secure();
 
         MAX_CONN_COUNTER.with(|conns| {
-            ok(NativeTlsAcceptorService {
+            future::ok(NativeTlsAcceptorService {
                 acceptor: self.acceptor.clone(),
                 conns: conns.clone(),
                 io: PhantomData,
@@ -70,30 +72,17 @@ pub struct NativeTlsAcceptorService<T, P> {
 
 impl<T: AsyncRead + AsyncWrite, P> Service for NativeTlsAcceptorService<T, P> {
     type Request = Io<T, P>;
-    type Response = Io<TlsStream<T>, P>;
+    type Response = Io<NativeTlsStream<T>, P>;
     type Error = Error;
     type Future = Accept<T, P>;
 
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        ctx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         if self.conns.available(ctx) {
-            Ok(Async::Ready(()))
+            Ok(Poll::Ready(Ok(())))
         } else {
-            Ok(Async::NotReady)
+            Ok(Poll::Pending)
         }
     }
-
-    /*
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        if self.conns.available() {
-            Ok(Async::Ready(()))
-        } else {
-            Ok(Async::NotReady)
-        }
-    }
-    */
 
     fn call(&mut self, req: Self::Request) -> Self::Future {
         let (io, params, _) = req.into_parts();
@@ -105,75 +94,74 @@ impl<T: AsyncRead + AsyncWrite, P> Service for NativeTlsAcceptorService<T, P> {
     }
 }
 
-/// A wrapper around an underlying raw stream which implements the TLS or SSL
-/// protocol.
-///
-/// A `TlsStream<S>` represents a handshake that has been completed successfully
-/// and both the server and the client are ready for receiving and sending
-/// data. Bytes read from a `TlsStream` are decrypted from `S` and bytes written
-/// to a `TlsStream` are encrypted when passing through to `S`.
-#[derive(Debug)]
-pub struct TlsStream<S> {
-    inner: native_tls::TlsStream<S>,
-}
-
 /// Future returned from `NativeTlsAcceptor::accept` which will resolve
 /// once the accept handshake has finished.
 pub struct Accept<S, P> {
-    inner: Option<Result<native_tls::TlsStream<S>, HandshakeError<S>>>,
+    inner: Option<Result<TlsStream<S>, HandshakeError<S>>>,
     params: Option<P>,
     _guard: CounterGuard,
 }
 
 impl<T: AsyncRead + AsyncWrite, P> Future for Accept<T, P> {
-    type Item = Io<TlsStream<T>, P>;
-    type Error = Error;
+    type Output = Result<Io<NativeTlsStream<T>, P>, Error>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.inner.take().expect("cannot poll MidHandshake twice") {
-            Ok(stream) => Ok(Async::Ready(Io::from_parts(
-                TlsStream { inner: stream },
-                self.params.take().unwrap(),
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let my = self.get_mut();
+        match my.inner.take().expect("cannot poll MidHandshake twice") {
+            Ok(stream) => Poll::Ready(Ok(Io::from_parts(
+                NativeTlsStream { inner: stream },
+                my.params.take().unwrap(),
                 Protocol::Unknown,
             ))),
-            Err(HandshakeError::Failure(e)) => Err(e),
+            Err(HandshakeError::Failure(e)) => Poll::Ready(Err(e)),
             Err(HandshakeError::WouldBlock(s)) => match s.handshake() {
-                Ok(stream) => Ok(Async::Ready(Io::from_parts(
-                    TlsStream { inner: stream },
-                    self.params.take().unwrap(),
+                Ok(stream) => Poll::Ready(Ok(Io::from_parts(
+                    NativeTlsStream { inner: stream },
+                    my.params.take().unwrap(),
                     Protocol::Unknown,
                 ))),
-                Err(HandshakeError::Failure(e)) => Err(e),
+                Err(HandshakeError::Failure(e)) => Poll::Ready(Err(e)),
                 Err(HandshakeError::WouldBlock(s)) => {
-                    self.inner = Some(Err(HandshakeError::WouldBlock(s)));
-                    Ok(Async::NotReady)
+                    my.inner = Some(Err(HandshakeError::WouldBlock(s)));
+                    // TODO: should we use Waker somehow?
+                    Poll::Pending
                 }
             },
         }
     }
 }
 
-impl<S> TlsStream<S> {
-    /// Get access to the internal `native_tls::TlsStream` stream which also
-    /// transitively allows access to `S`.
-    pub fn get_ref(&self) -> &native_tls::TlsStream<S> {
+/// A wrapper around an underlying raw stream which implements the TLS or SSL
+/// protocol.
+///
+/// A `NativeTlsStream<S>` represents a handshake that has been completed successfully
+/// and both the server and the client are ready for receiving and sending
+/// data. Bytes read from a `NativeTlsStream` are decrypted from `S` and bytes written
+/// to a `NativeTlsStream` are encrypted when passing through to `S`.
+#[derive(Debug)]
+pub struct NativeTlsStream<S> {
+    inner: TlsStream<S>,
+}
+
+impl<S> AsRef<TlsStream<S>> for NativeTlsStream<S> {
+    fn as_ref(&self) -> &TlsStream<S> {
         &self.inner
     }
+}
 
-    /// Get mutable access to the internal `native_tls::TlsStream` stream which
-    /// also transitively allows mutable access to `S`.
-    pub fn get_mut(&mut self) -> &mut native_tls::TlsStream<S> {
+impl<S> AsMut<TlsStream<S>> for NativeTlsStream<S> {
+    fn as_mut(&mut self) -> &mut TlsStream<S> {
         &mut self.inner
     }
 }
 
-impl<S: io::Read + io::Write> io::Read for TlsStream<S> {
+impl<S: io::Read + io::Write> io::Read for NativeTlsStream<S> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
     }
 }
 
-impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
+impl<S: io::Read + io::Write> io::Write for NativeTlsStream<S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.write(buf)
     }
@@ -183,15 +171,40 @@ impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
     }
 }
 
-impl<S: AsyncRead + AsyncWrite> AsyncRead for TlsStream<S> {}
+impl<S: AsyncRead + AsyncWrite> AsyncRead for NativeTlsStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        // TODO: wha?
+        unimplemented!()
+    }
+}
 
-impl<S: AsyncRead + AsyncWrite> AsyncWrite for TlsStream<S> {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        match self.inner.shutdown() {
+impl<S: AsyncRead + AsyncWrite> AsyncWrite for NativeTlsStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        unimplemented!()
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        unimplemented!()
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        let inner = &mut Pin::get_mut(self).inner;
+        match inner.shutdown() {
             Ok(_) => (),
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => (),
-            Err(e) => return Err(e),
+            Err(e) => return Poll::Ready(Err(e)),
         }
-        self.inner.get_mut().shutdown()
+        inner.get_mut().poll_shutdown()
     }
 }


### PR DESCRIPTION
## Changes

### actix-server-config

- Remove `"uds"` feature (`tokio` provides it along with its default features).
- Rename features: `"ssl"` -> `"openssl"`, `"rust-tls"` -> `"rustls"` (for being more clear).
- Unmake features being enabled by default (as `master` has).
- Remove unused dependencies.

### actix-server

- Migrate `ssl::nativetls` module to `std::future` via using [`tokio-tls`](https://docs.rs/tokio-tls/0.3.0-alpha.6/tokio_tls) crate. The previous implementation cannot be transported "as is" due to necessity of passing `Waker` explicitly (previously it was taken from TLS under-the-hood).
- Rename features: `"tls"` -> `"nativetls"`, `"ssl"` -> `"openssl"`, `"rust-tls"` -> `"rustls"` (for consistency with `actix-server-config` and modules names).