### PR TITLE
Fix for non Unix

### DIFF
--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -53,6 +53,7 @@ pub mod net {
         pub use tokio::net::{UnixDatagram, UnixListener, UnixStream};
     }
 
+    #[cfg(unix)]
     pub use self::unix::*;
 }
 

--- a/actix-server/src/signals.rs
+++ b/actix-server/src/signals.rs
@@ -11,12 +11,15 @@ use crate::server::Server;
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub(crate) enum Signal {
     /// SIGHUP
+    #[cfg_attr(not(unix), allow(dead_code))]
     Hup,
     /// SIGINT
     Int,
     /// SIGTERM
+    #[cfg_attr(not(unix), allow(dead_code))]
     Term,
     /// SIGQUIT
+    #[cfg_attr(not(unix), allow(dead_code))]
     Quit,
 }
 
@@ -69,7 +72,7 @@ impl Future for Signals {
         #[cfg(not(unix))]
         loop {
             match Pin::new(&mut self.stream).poll_next(cx) {
-                Poll::Ready(Ok(Some(_))) => self.srv.signal(Signal::Int),
+                Poll::Ready(Some(_)) => self.srv.signal(Signal::Int),
                 Poll::Ready(None) => return Poll::Ready(()),
                 Poll::Pending => return Poll::Pending,
             }


### PR DESCRIPTION
 Warnings were turned into errors, but windows doesn't construct 3 of the variants.