### PR TITLE
Stop running tests for all features on Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,4 +55,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features -- --nocapture
+          args: --all -- --nocapture


### PR DESCRIPTION
The current check suite on Windows is unhelpful. Until we come up with the way to compile `rust-openssl` on Windows, I'd like to stop running tests for all features on Actions.