### PR TITLE
Macro improvements.

### DIFF
--- a/actix-macros/src/lib.rs
+++ b/actix-macros/src/lib.rs
@@ -18,24 +18,23 @@ use quote::quote;
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main(_: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
-
-    let ret = &input.sig.output;
-    let name = &input.sig.ident;
-    let inputs = &input.sig.inputs;
-    let body = &input.block;
     let attrs = &input.attrs;
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let body = &input.block;
+    let name = &sig.ident;
 
-    if input.sig.asyncness.is_none() {
-        return syn::Error::new_spanned(input.sig.fn_token, "only async fn is supported")
+    if sig.asyncness.is_none() {
+        return syn::Error::new_spanned(sig.fn_token, "only async fn is supported")
             .to_compile_error()
             .into();
     }
 
     (quote! {
         #(#attrs)*
-        fn #name(#inputs) #ret {
-            actix_rt::System::new("main")
-                .block_on(async { #body })
+        #vis #sig {
+            actix_rt::System::new(stringify!(#name))
+                .block_on(async move { #body })
         }
     })
     .into()

--- a/actix-macros/src/lib.rs
+++ b/actix-macros/src/lib.rs
@@ -17,10 +17,10 @@ use quote::quote;
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main(_: TokenStream, item: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let mut input = syn::parse_macro_input!(item as syn::ItemFn);
     let attrs = &input.attrs;
     let vis = &input.vis;
-    let sig = &input.sig;
+    let sig = &mut input.sig;
     let body = &input.block;
     let name = &sig.ident;
 
@@ -29,6 +29,8 @@ pub fn main(_: TokenStream, item: TokenStream) -> TokenStream {
             .to_compile_error()
             .into();
     }
+
+    sig.asyncness = None;
 
     (quote! {
         #(#attrs)*


### PR DESCRIPTION
Some improvements to `#[actix_rt::main]`, sepcifically support to add it to anything else then `fn main()`, that means adding generics, visibility modifiers and so on.