### PR TITLE
actix-connect: Update trust-dns-resolver to a release

### DIFF
--- a/actix-connect/Cargo.toml
+++ b/actix-connect/Cargo.toml
@@ -41,8 +41,7 @@ either = "1.5.2"
 futures = "0.3.1"
 http = { version = "0.2.0", optional = true }
 log = "0.4"
-trust-dns-proto = "=0.18.0-alpha.2"
-trust-dns-resolver = "=0.18.0-alpha.2"
+trust-dns-resolver = "0.18.0"
 
 # openssl
 open-ssl = { version="0.10", package = "openssl", optional = true }


### PR DESCRIPTION
It is much better to use release version instead of pinned pre-release.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>