### PR TITLE
Optimize vector fill in builder.

### DIFF
--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -263,12 +263,12 @@ impl ServerBuilder {
             info!("Starting {} workers", self.threads);
 
             // start workers
-            let mut workers = Vec::new();
-            for idx in 0..self.threads {
+            let workers = (0..self.threads).map(|idx| {
                 let worker = self.start_worker(idx, self.accept.get_notify());
-                workers.push(worker.clone());
-                self.workers.push((idx, worker));
-            }
+                self.workers.push((idx, worker.clone()));
+
+                worker
+            }).collect();
 
             // start accept thread
             for sock in &self.sockets {

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -263,12 +263,14 @@ impl ServerBuilder {
             info!("Starting {} workers", self.threads);
 
             // start workers
-            let workers = (0..self.threads).map(|idx| {
-                let worker = self.start_worker(idx, self.accept.get_notify());
-                self.workers.push((idx, worker.clone()));
+            let workers = (0..self.threads)
+                .map(|idx| {
+                    let worker = self.start_worker(idx, self.accept.get_notify());
+                    self.workers.push((idx, worker.clone()));
 
-                worker
-            }).collect();
+                    worker
+                })
+                .collect();
 
             // start accept thread
             for sock in &self.sockets {
@@ -380,7 +382,7 @@ impl ServerBuilder {
                                             .await;
                                             System::current().stop();
                                         }
-                                        .boxed(),
+                                            .boxed(),
                                     );
                                 }
                                 ready(())


### PR DESCRIPTION
Original code uses `Vec::new` and then adds entries multiple times through `push`. That can cause unnecessary memory reallocation and capacity checks. There commits should fix it using range with map.