### PR TITLE
Allow awaiting for futures spawned on current arbiter

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Expose `System::is_set` to check if current system is running
 
+- Add `Arbiter::local_join` associated function to get be able to `await` for spawned futures
+
 ## [1.0.0] - 2019-12-11
 
 * Update dependencies

--- a/actix-rt/tests/wait_spawned.rs
+++ b/actix-rt/tests/wait_spawned.rs
@@ -61,3 +61,40 @@ fn join_another_arbiter() {
         "Premature stop of arbiter should conclude regardless of it's current state"
     );
 }
+
+#[test]
+fn join_current_arbiter() {
+    let time = Duration::from_secs(2);
+
+    let instant = Instant::now();
+    actix_rt::System::new("test_join_current_arbiter").block_on(async move {
+        actix_rt::spawn(async move {
+            tokio::time::delay_for(time).await;
+            actix_rt::Arbiter::current().stop();
+        });
+        actix_rt::Arbiter::local_join().await;
+    });
+    assert!(
+        instant.elapsed() >= time,
+        "Join on current arbiter should wait for all spawned futures"
+    );
+
+    let large_timer = Duration::from_secs(20);
+    let instant = Instant::now();
+    actix_rt::System::new("test_join_current_arbiter").block_on(async move {
+        actix_rt::spawn(async move {
+            tokio::time::delay_for(time).await;
+            actix_rt::Arbiter::current().stop();
+        });
+        let f = actix_rt::Arbiter::local_join();
+        actix_rt::spawn(async move {
+            tokio::time::delay_for(large_timer).await;
+            actix_rt::Arbiter::current().stop();
+        });
+        f.await;
+    });
+    assert!(
+        instant.elapsed() < large_timer,
+        "local_join should await only for the already spawned futures"
+    );
+}

--- a/actix-rt/tests/wait_spawned.rs
+++ b/actix-rt/tests/wait_spawned.rs
@@ -1,0 +1,63 @@
+use std::time::{Duration, Instant};
+
+#[test]
+fn await_for_timer() {
+    let time = Duration::from_secs(2);
+    let instant = Instant::now();
+    actix_rt::System::new("test_wait_timer").block_on(async move {
+        tokio::time::delay_for(time).await;
+    });
+    assert!(
+        instant.elapsed() >= time,
+        "Block on should poll awaited future to completion"
+    );
+}
+
+#[test]
+fn join_another_arbiter() {
+    let time = Duration::from_secs(2);
+    let instant = Instant::now();
+    actix_rt::System::new("test_join_another_arbiter").block_on(async move {
+        let mut arbiter = actix_rt::Arbiter::new();
+        arbiter.send(Box::pin(async move {
+            tokio::time::delay_for(time).await;
+            actix_rt::Arbiter::current().stop();
+        }));
+        arbiter.join().unwrap();
+    });
+    assert!(
+        instant.elapsed() >= time,
+        "Join on another arbiter should complete only when it calls stop"
+    );
+
+    let instant = Instant::now();
+    actix_rt::System::new("test_join_another_arbiter").block_on(async move {
+        let mut arbiter = actix_rt::Arbiter::new();
+        arbiter.exec_fn(move || {
+            actix_rt::spawn(async move {
+                tokio::time::delay_for(time).await;
+                actix_rt::Arbiter::current().stop();
+            });
+        });
+        arbiter.join().unwrap();
+    });
+    assert!(
+        instant.elapsed() >= time,
+        "Join on a arbiter that has used actix_rt::spawn should wait for said future"
+    );
+
+    let instant = Instant::now();
+    actix_rt::System::new("test_join_another_arbiter").block_on(async move {
+        let mut arbiter = actix_rt::Arbiter::new();
+        arbiter.send(Box::pin(async move {
+            tokio::time::delay_for(time).await;
+            actix_rt::Arbiter::current().stop();
+        }));
+        arbiter.stop();
+        arbiter.join().unwrap();
+    });
+    assert!(
+        instant.elapsed() < time,
+        "Premature stop of arbiter should conclude regardless of it's current state"
+    );
+}


### PR DESCRIPTION
This PR includes essentially two changes: (1) a basic integration test is added, the test validate runtime execution semantics using `tokio::time::delay_for` and elapsed time to ensure futures are being driven to completion; (2) a `Arbiter::local_join` function was added, I'll focus the rest of this description about it.

# Motivation
When we're is doing computation to a newly allocated `Arbiter`one can use `Arbiter::join`in order to wait for it's completion, however when futures are spawned to the current arbiter we can lose track of it's completion status. Some crates, like actix will [eventually spawn futures to the current Arbiter](https://github.com/actix/actix/blob/f5eda8c75b1404a6215a396f23cc36f820ea7ef3/src/context.rs#L107), and it seams that there's no way of asking the system rather any of them are still running.

# Solution
The added `Arbiter::local_join`, a associated function that will return a future that will only complete once all current spawned futures have completed.

# Implementation
Since we use `tokio::task::spawn_local` which returns a [JoinHandle](https://docs.rs/tokio/0.2.11/tokio/task/struct.JoinHandle.html) to the spawned future, it's pretty doable to keep track of future's progress (maybe even resolved value later on).

So now all spawned futures's JoinHandle are put into a buffer of spawned futures, when one asks for a `Arbiter::local_join` this buffer is cleared and a `Future` is returned that will be resolved once all spawned futures have have finished.

# Future work
I believe it would be viable to change the API so functions like `actix_rt::spawn` can have a return value and are responded with a handle that can be used to access it if the user so desires.