### PR TITLE
Benchmarks for actix-service: focused around UnsafeCell usage

### DIFF
--- a/actix-service/Cargo.toml
+++ b/actix-service/Cargo.toml
@@ -21,3 +21,8 @@ pin-project = "0.4.6"
 
 [dev-dependencies]
 actix-rt = "1.0.0"
+criterion = "0.3"
+
+[[bench]]
+name = "unsafecell_vs_refcell"
+harness = false

--- a/actix-service/Cargo.toml
+++ b/actix-service/Cargo.toml
@@ -26,3 +26,7 @@ criterion = "0.3"
 [[bench]]
 name = "unsafecell_vs_refcell"
 harness = false
+
+[[bench]]
+name = "and_then"
+harness = false

--- a/actix-service/benches/and_then.rs
+++ b/actix-service/benches/and_then.rs
@@ -316,6 +316,8 @@ pub fn service_benches() {
         ::criterion::Criterion::default().configure_from_args();
     bench_async_service(&mut criterion, AndThenUC::new(svc1.into_service(), svc2.into_service()), "AndThen with UnsafeCell");
     bench_async_service(&mut criterion, AndThenRC::new(svc1.into_service(), svc2.into_service()), "AndThen with RefCell");
+    bench_async_service(&mut criterion, AndThenUC::new(svc1.into_service(), svc2.into_service()), "AndThen with UnsafeCell");
+    bench_async_service(&mut criterion, AndThenRC::new(svc1.into_service(), svc2.into_service()), "AndThen with RefCell");
     bench_async_service(&mut criterion, AndThenRCFuture::new(svc1.into_service(), svc2.into_service()), "AndThen with RefCell via future::and_then");
 }
 

--- a/actix-service/benches/and_then.rs
+++ b/actix-service/benches/and_then.rs
@@ -1,0 +1,322 @@
+/// Benchmark various implementations of and_then
+
+use criterion::{criterion_main, Criterion};
+use futures_util::future::join_all;
+use std::cell::{RefCell, UnsafeCell};
+use std::task::{Context, Poll};
+use std::rc::Rc;
+use actix_service::{Service};
+use actix_service::IntoService;
+use std::future::Future;
+use std::pin::Pin;
+use futures_util::future::TryFutureExt;
+use actix_service::boxed::BoxFuture;
+
+
+/*
+ * Test services A,B for AndThen service implementations
+ */
+
+async fn svc1(_: ()) -> Result<usize, ()> {
+	Ok(1)
+}
+
+async fn svc2(req: usize) -> Result<usize, ()> {
+	Ok(req + 1)
+}
+
+/*
+ * AndThenUC - original AndThen service based on UnsafeCell
+ * Cut down version of actix_service::AndThenService based on actix-service::Cell
+ */
+
+
+struct AndThenUC<A,B>(Rc<UnsafeCell<(A, B)>>);
+
+impl<A,B> AndThenUC<A,B> {
+	fn new(a: A, b: B) -> Self
+	where
+		A: Service,
+		B: Service<Request = A::Response, Error = A::Error>,
+	{
+		Self(Rc::new(UnsafeCell::new((a,b))))
+	}
+}
+
+impl<A,B> Clone for AndThenUC<A,B> {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}
+
+impl<A,B> Service for AndThenUC<A,B>
+where
+    A: Service,
+    B: Service<Request = A::Response, Error = A::Error>
+{
+	type Request = A::Request;
+	type Response = B::Response;
+	type Error = A::Error;
+	type Future = AndThenServiceResponse<A,B>;
+
+	fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
+	}
+
+	fn call(&mut self, req: A::Request) -> Self::Future {
+		let fut = unsafe { &mut *(*self.0).get() }.0.call(req);
+		AndThenServiceResponse {
+			state: State::A(fut, Some(self.0.clone()))
+		}
+	}
+}
+
+#[pin_project::pin_project]
+pub(crate) struct AndThenServiceResponse<A, B>
+where
+    A: Service,
+    B: Service<Request = A::Response, Error = A::Error>,
+{
+    #[pin]
+    state: State<A, B>,
+}
+
+#[pin_project::pin_project]
+enum State<A, B>
+where
+    A: Service,
+    B: Service<Request = A::Response, Error = A::Error>,
+{
+    A(#[pin] A::Future, Option<Rc<UnsafeCell<(A, B)>>>),
+    B(#[pin] B::Future),
+    Empty,
+}
+
+impl<A, B> Future for AndThenServiceResponse<A, B>
+where
+    A: Service,
+    B: Service<Request = A::Response, Error = A::Error>,
+{
+    type Output = Result<B::Response, A::Error>;
+
+    #[pin_project::project]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.as_mut().project();
+
+        #[project]
+        match this.state.as_mut().project() {
+            State::A(fut, b) => match fut.poll(cx)? {
+                Poll::Ready(res) => {
+                    let b = b.take().unwrap();
+                    this.state.set(State::Empty); // drop fut A
+                    let fut = unsafe { &mut (*b.get()).1 }.call(res);
+                    this.state.set(State::B(fut));
+                    self.poll(cx)
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            State::B(fut) => fut.poll(cx).map(|r| {
+                this.state.set(State::Empty);
+                r
+            }),
+            State::Empty => panic!("future must not be polled after it returned `Poll::Ready`"),
+        }
+    }
+}
+
+
+/*
+ * AndThenRC - AndThen service based on RefCell
+ */
+
+ struct AndThenRC<A,B>(Rc<RefCell<(A, B)>>);
+
+ impl<A,B> AndThenRC<A,B> {
+	 fn new(a: A, b: B) -> Self
+	 where
+		 A: Service,
+		 B: Service<Request = A::Response, Error = A::Error>,
+	 {
+		 Self(Rc::new(RefCell::new((a,b))))
+	 }
+ }
+ 
+ impl<A,B> Clone for AndThenRC<A,B> {
+	 fn clone(&self) -> Self {
+		 Self(self.0.clone())
+	 }
+ }
+ 
+ impl<A,B> Service for AndThenRC<A,B>
+ where
+	 A: Service,
+	 B: Service<Request = A::Response, Error = A::Error>
+ {
+	 type Request = A::Request;
+	 type Response = B::Response;
+	 type Error = A::Error;
+	 type Future = AndThenServiceResponseRC<A,B>;
+ 
+	 fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		 Poll::Ready(Ok(()))
+	 }
+ 
+	 fn call(&mut self, req: A::Request) -> Self::Future {
+		 let fut = self.0.borrow_mut().0.call(req);
+		 AndThenServiceResponseRC {
+			 state: StateRC::A(fut, Some(self.0.clone()))
+		 }
+	 }
+ }
+ 
+ #[pin_project::pin_project]
+ pub(crate) struct AndThenServiceResponseRC<A, B>
+ where
+	 A: Service,
+	 B: Service<Request = A::Response, Error = A::Error>,
+ {
+	 #[pin]
+	 state: StateRC<A, B>,
+ }
+ 
+ #[pin_project::pin_project]
+ enum StateRC<A, B>
+ where
+	 A: Service,
+	 B: Service<Request = A::Response, Error = A::Error>,
+ {
+	 A(#[pin] A::Future, Option<Rc<RefCell<(A, B)>>>),
+	 B(#[pin] B::Future),
+	 Empty,
+ }
+ 
+ impl<A, B> Future for AndThenServiceResponseRC<A, B>
+ where
+	 A: Service,
+	 B: Service<Request = A::Response, Error = A::Error>,
+ {
+	 type Output = Result<B::Response, A::Error>;
+ 
+	 #[pin_project::project]
+	 fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		 let mut this = self.as_mut().project();
+ 
+		 #[project]
+		 match this.state.as_mut().project() {
+			 StateRC::A(fut, b) => match fut.poll(cx)? {
+				 Poll::Ready(res) => {
+					 let b = b.take().unwrap();
+					 this.state.set(StateRC::Empty); // drop fut A
+					 let fut = b.borrow_mut().1.call(res);
+					 this.state.set(StateRC::B(fut));
+					 self.poll(cx)
+				 }
+				 Poll::Pending => Poll::Pending,
+			 },
+			 StateRC::B(fut) => fut.poll(cx).map(|r| {
+				 this.state.set(StateRC::Empty);
+				 r
+			 }),
+			 StateRC::Empty => panic!("future must not be polled after it returned `Poll::Ready`"),
+		 }
+	 }
+ }
+ 
+
+ /*
+ * AndThenRCFuture - AndThen service based on RefCell 
+ * and standard futures::future::and_then combinator in a Box
+ */
+
+ struct AndThenRCFuture<A,B>(Rc<RefCell<(A, B)>>);
+
+ impl<A,B> AndThenRCFuture<A,B> {
+	 fn new(a: A, b: B) -> Self
+	 where
+		 A: Service,
+		 B: Service<Request = A::Response, Error = A::Error>,
+	 {
+		 Self(Rc::new(RefCell::new((a,b))))
+	 }
+ }
+ 
+ impl<A,B> Clone for AndThenRCFuture<A,B> {
+	 fn clone(&self) -> Self {
+		 Self(self.0.clone())
+	 }
+ }
+ 
+ impl<A,B> Service for AndThenRCFuture<A,B>
+ where
+	A: Service + 'static,
+	A::Future: 'static,
+	B: Service<Request = A::Response, Error = A::Error> + 'static,
+ 	B::Future: 'static
+ {
+	 type Request = A::Request;
+	 type Response = B::Response;
+	 type Error = A::Error;
+	 type Future = BoxFuture<Self::Response, Self::Error>;
+ 
+	 fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		 Poll::Ready(Ok(()))
+	 }
+ 
+	 fn call(&mut self, req: A::Request) -> Self::Future {
+		 let fut = self.0.borrow_mut().0.call(req);
+		 let core = self.0.clone();
+		 let fut2 = move |res| (*core).borrow_mut().1.call(res);
+		 Box::pin(
+			fut.and_then(fut2)
+		)
+	 }
+ }
+ 
+
+/// Criterion Benchmark for async Service
+/// Should be used from within criterion group:
+/// ```rust,ignore
+/// let mut criterion: ::criterion::Criterion<_> =
+///     ::criterion::Criterion::default().configure_from_args();
+/// bench_async_service(&mut criterion, ok_service(), "async_service_direct");
+/// ```
+///
+/// Usable for benching Service wrappers:
+/// Using minimum service code implementation we first measure
+/// time to run minimum service, then measure time with wrapper.
+///
+/// Sample output
+/// async_service_direct    time:   [1.0908 us 1.1656 us 1.2613 us]
+pub fn bench_async_service<S>(c: &mut Criterion, srv: S, name: &str)
+where
+    S: Service<Request = (), Response = usize, Error = ()> + Clone + 'static,
+{
+    let mut rt = actix_rt::System::new("test");
+
+    // start benchmark loops
+    c.bench_function(name, move |b| {
+        b.iter_custom(|iters| {
+            let mut srvs: Vec<_> = (1..iters).map(|_| srv.clone()).collect();
+            // exclude request generation, it appears it takes significant time vs call (3us vs 1us)
+            let start = std::time::Instant::now();
+            // benchmark body
+            rt.block_on(async move {
+				join_all(srvs.iter_mut().map(|srv| srv.call(()))).await
+			});
+            let elapsed = start.elapsed();
+            // check that at least first request succeeded
+            elapsed
+        })
+    });
+}
+
+
+pub fn service_benches() {
+    let mut criterion: ::criterion::Criterion<_> =
+        ::criterion::Criterion::default().configure_from_args();
+    bench_async_service(&mut criterion, AndThenUC::new(svc1.into_service(), svc2.into_service()), "AndThen with UnsafeCell");
+    bench_async_service(&mut criterion, AndThenRC::new(svc1.into_service(), svc2.into_service()), "AndThen with RefCell");
+    bench_async_service(&mut criterion, AndThenRCFuture::new(svc1.into_service(), svc2.into_service()), "AndThen with RefCell via future::and_then");
+}
+
+criterion_main!(service_benches);

--- a/actix-service/benches/unsafecell_vs_refcell.rs
+++ b/actix-service/benches/unsafecell_vs_refcell.rs
@@ -1,0 +1,115 @@
+use criterion::{criterion_main, Criterion};
+use futures_util::future::join_all;
+use std::cell::{RefCell, UnsafeCell};
+use std::task::{Context, Poll};
+use std::rc::Rc;
+use actix_service::{Service};
+use futures_util::future::{ok, Ready};
+
+struct SrvUC(Rc<UnsafeCell<usize>>);
+
+impl Default for SrvUC {
+	fn default() -> Self {
+		Self(Rc::new(UnsafeCell::new(0)))
+	}
+}
+
+impl Clone for SrvUC {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}
+
+impl Service for SrvUC {
+	type Request = ();
+	type Response = usize;
+	type Error = ();
+	type Future = Ready<Result<Self::Response, ()>>;
+
+	fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
+	}
+
+	fn call(&mut self, _: ()) -> Self::Future {
+		unsafe { *(*self.0).get() = *(*self.0).get() + 1 };
+		ok(unsafe { *self.0.get() })
+	}
+}
+
+struct SrvRC(Rc<RefCell<usize>>);
+
+impl Default for SrvRC {
+	fn default() -> Self {
+		Self(Rc::new(RefCell::new(0)))
+	}
+}
+
+impl Clone for SrvRC {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}
+
+impl Service for SrvRC {
+	type Request = ();
+	type Response = usize;
+	type Error = ();
+	type Future = Ready<Result<Self::Response, ()>>;
+
+	fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
+	}
+
+	fn call(&mut self, req: ()) -> Self::Future {
+		let prev = *self.0.borrow();
+		*(*self.0).borrow_mut() = prev + 1;
+		ok(*self.0.borrow())
+	}
+}
+
+
+/// Criterion Benchmark for async Service
+/// Should be used from within criterion group:
+/// ```rust,ignore
+/// let mut criterion: ::criterion::Criterion<_> =
+///     ::criterion::Criterion::default().configure_from_args();
+/// bench_async_service(&mut criterion, ok_service(), "async_service_direct");
+/// ```
+///
+/// Usable for benching Service wrappers:
+/// Using minimum service code implementation we first measure
+/// time to run minimum service, then measure time with wrapper.
+///
+/// Sample output
+/// async_service_direct    time:   [1.0908 us 1.1656 us 1.2613 us]
+pub fn bench_async_service<S>(c: &mut Criterion, srv: S, name: &str)
+where
+    S: Service<Request = (), Response = usize, Error = ()> + Clone + 'static,
+{
+    let mut rt = actix_rt::System::new("test");
+
+    // start benchmark loops
+    c.bench_function(name, move |b| {
+        b.iter_custom(|iters| {
+            let mut srvs: Vec<_> = (1..iters).map(|_| srv.clone()).collect();
+            // exclude request generation, it appears it takes significant time vs call (3us vs 1us)
+            let start = std::time::Instant::now();
+            // benchmark body
+            rt.block_on(async move {
+				join_all(srvs.iter_mut().map(|srv| srv.call(()))).await
+			});
+            let elapsed = start.elapsed();
+            // check that at least first request succeeded
+            elapsed
+        })
+    });
+}
+
+
+pub fn service_benches() {
+    let mut criterion: ::criterion::Criterion<_> =
+        ::criterion::Criterion::default().configure_from_args();
+    bench_async_service(&mut criterion, SrvUC::default(), "Service with UnsafeCell");
+    bench_async_service(&mut criterion, SrvRC::default(), "Service with RefCell");
+}
+criterion_main!(service_benches);

--- a/actix-service/benches/unsafecell_vs_refcell.rs
+++ b/actix-service/benches/unsafecell_vs_refcell.rs
@@ -60,7 +60,7 @@ impl Service for SrvRC {
 		Poll::Ready(Ok(()))
 	}
 
-	fn call(&mut self, req: ()) -> Self::Future {
+	fn call(&mut self, _: ()) -> Self::Future {
 		let prev = *self.0.borrow();
 		*(*self.0).borrow_mut() = prev + 1;
 		ok(*self.0.borrow())

--- a/actix-service/benches/unsafecell_vs_refcell.rs
+++ b/actix-service/benches/unsafecell_vs_refcell.rs
@@ -111,5 +111,7 @@ pub fn service_benches() {
         ::criterion::Criterion::default().configure_from_args();
     bench_async_service(&mut criterion, SrvUC::default(), "Service with UnsafeCell");
     bench_async_service(&mut criterion, SrvRC::default(), "Service with RefCell");
+    bench_async_service(&mut criterion, SrvUC::default(), "Service with UnsafeCell");
+    bench_async_service(&mut criterion, SrvRC::default(), "Service with RefCell");
 }
 criterion_main!(service_benches);


### PR DESCRIPTION
Actix-service would benefit some white box benchmarks. For instance if I would want to look at what can be done with current implementation of a Cell, it would be easier to judge is there any affordable and safe solution.

This PR is adding basic performance testing facility for alternate implementations of a service, specifically one is using UnsafeCell vs RefCell implementation. Benchmarks repeating to avoid mistake of a first run.

Specifically AndThenService benchmark (bench/and_then.rs) compares 3 implementations:
1. Current via Cell which is Rc<UnsafeCell<(A,B)>>
1. RefCell via Rc<RefCell<(A,B)>>
1. RefCell via Rc<RefCell<(A,B)>> where instead of custom baked AndThen state combinator standard Future AndThen is used (though that required to wrap future in a Box)

Results are surprising and vary depending on OS/architecture:
*Mac OS X i5 2.6GHz*
```
AndThen with UnsafeCell #2 time:   [50.931 ns 51.918 ns 53.378 ns]
AndThen with RefCell #2 time:   [51.276 ns 51.782 ns 52.348 ns]
AndThen with RefCell via future::and_then                                                                            
                        time:   [225.47 ns 228.73 ns 232.46 ns]
```
*Ubuntu 18 Xeon E5-2660 W2*
```
AndThen with UnsafeCell #2 time:   [44.421 ns 46.810 ns 49.167 ns]
AndThen with RefCell #2 time:   [48.391 ns 48.972 ns 49.514 ns]
AndThen with RefCell via future::and_then
                        time:   [93.348 ns 93.799 ns 94.261 ns]
```

It consistently shows that standard Future combinators are slower. Though RefCell seems similar or marginally slower which might be just mistake of measurement (1-2ns?).

Similar results for "primitive" cell service comparison (bench/unsafecell_vs_refcell.rs):
```
Service with UnsafeCell #2 time:   [27.171 ns 29.248 ns 31.067 ns]
Service with RefCell #2 time:   [28.457 ns 30.320 ns 31.935 ns]
```

If there are any other ideas for implementation I would like to extend these benchmarks trying those ideas.