### PR TITLE
Expose is_set

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [TBD] - [TBD]
+
+- Expose `System::is_set` to check if current system is running
+
 ## [1.0.0] - 2019-12-11
 
 * Update dependencies

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -79,8 +79,8 @@ impl System {
         })
     }
 
-    /// Set current running system.
-    pub(crate) fn is_set() -> bool {
+    /// Check current system is running.
+    pub fn is_set() -> bool {
         CURRENT.with(|cell| cell.borrow().is_some())
     }
 

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -79,7 +79,7 @@ impl System {
         })
     }
 
-    /// Check current system is running.
+    /// Check if current system is running.
     pub fn is_set() -> bool {
         CURRENT.with(|cell| cell.borrow().is_some())
     }


### PR DESCRIPTION
In a situation I need check if there's a currently running actix system, but not panic when there isn't. This pub crate function just works and seems not dangerous to expose it.