### PR TITLE
Replace calls to `Pin::new_unchecked` with `pin_project`.

### DIFF
--- a/actix-codec/Cargo.toml
+++ b/actix-codec/Cargo.toml
@@ -24,3 +24,4 @@ futures-sink = "0.3.1"
 tokio = { version = "0.2.4", default-features=false }
 tokio-util = { version = "0.2.0", default-features=false, features=["codec"] }
 log = "0.4"
+pin-project = "0.4.8"

--- a/actix-ioframe/src/service.rs
+++ b/actix-ioframe/src/service.rs
@@ -357,7 +357,7 @@ where
 {
     Connect(#[pin] C::Future, Rc<T>),
     Handler(#[pin] T::Future, Option<Framed<Io, Codec>>, Option<Out>),
-    Dispatcher(Dispatcher<T::Service, Io, Codec, Out>),
+    Dispatcher(#[pin] Dispatcher<T::Service, Io, Codec, Out>),
 }
 
 impl<St, Io, Codec, Out, C, T> FramedServiceImplResponseInner<St, Io, Codec, Out, C, T>
@@ -408,7 +408,7 @@ where
                     Poll::Ready(Err(e)) => Either::Right(Poll::Ready(Err(e.into()))),
                 }
             }
-            FramedServiceImplResponseInner::Dispatcher(ref mut fut) => {
+            FramedServiceImplResponseInner::Dispatcher(fut) => {
                 Either::Right(fut.poll(cx))
             }
         }

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -181,7 +181,7 @@ impl Arbiter {
                 // because the executor boxes the future again, but works for now
                 Q.with(move |cell| {
                     cell.borrow_mut()
-                        .push(unsafe { Pin::new_unchecked(Box::alloc().init(future)) })
+                        .push(Pin::from(Box::alloc().init(future)))
                 });
             }
         });


### PR DESCRIPTION
This is a breaking change, as it changes some public methods to take
`Pin<&mut Self>` rather than `&mut self`.

This brings these methods into line with `Stream::poll_next`, which also
takes a `Pin<&mut Self>`