### PR TITLE
actix-connect: Upgrade versions of trust-dns

### DIFF
--- a/actix-connect/CHANGES.md
+++ b/actix-connect/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## [TBD] - TBD
+
+### Changed
+
+* Update `trust-dns-proto` dependency to 0.19 [#116]
+* Update `trust-dns-resolver` dependency to 0.19 [#116]
+* `Address` trait is now required to have static lifetime [#116]
+* `start_resolver` and `start_default_resolver` are now `async` and may return a `ConnectError` [#116]
+
 ## [2.0.0-alpha.1] - 2020-03-03
 
 ### Changed

--- a/actix-connect/Cargo.toml
+++ b/actix-connect/Cargo.toml
@@ -40,8 +40,8 @@ either = "1.5.3"
 futures = "0.3.1"
 http = { version = "0.2.0", optional = true }
 log = "0.4"
-trust-dns-proto = "=0.18.0-alpha.2"
-trust-dns-resolver = "=0.18.0-alpha.2"
+trust-dns-proto = { version = "0.19", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.19", default-features = false, features = ["tokio-runtime", "system-config"] }
 
 # openssl
 open-ssl = { version="0.10", package = "openssl", optional = true }

--- a/actix-connect/src/connect.rs
+++ b/actix-connect/src/connect.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use either::Either;
 
 /// Connect request
-pub trait Address: Unpin {
+pub trait Address: Unpin + 'static {
     /// Host name of the request
     fn host(&self) -> &str;
 

--- a/actix-connect/src/resolve.rs
+++ b/actix-connect/src/resolve.rs
@@ -6,8 +6,8 @@ use std::task::{Context, Poll};
 
 use actix_service::{Service, ServiceFactory};
 use futures::future::{ok, Either, Ready};
-use trust_dns_resolver::lookup_ip::LookupIpFuture;
-use trust_dns_resolver::{AsyncResolver, Background};
+use trust_dns_resolver::TokioAsyncResolver as AsyncResolver;
+use trust_dns_resolver::{error::ResolveError, lookup_ip::LookupIp};
 
 use crate::connect::{Address, Connect};
 use crate::error::ConnectError;
@@ -106,7 +106,10 @@ impl<T: Address> Service for Resolver<T> {
     type Request = Connect<T>;
     type Response = Connect<T>;
     type Error = ConnectError;
-    type Future = Either<ResolverFuture<T>, Ready<Result<Connect<T>, Self::Error>>>;
+    type Future = Either<
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>,
+        Ready<Result<Connect<T>, Self::Error>>,
+    >;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -119,32 +122,48 @@ impl<T: Address> Service for Resolver<T> {
             req.addr = Some(either::Either::Left(SocketAddr::new(ip, req.port())));
             Either::Right(ok(req))
         } else {
-            trace!("DNS resolver: resolving host {:?}", req.host());
-            if self.resolver.is_none() {
-                self.resolver = Some(get_default_resolver());
-            }
-            Either::Left(ResolverFuture::new(req, self.resolver.as_ref().unwrap()))
+            let resolver = self.resolver.as_ref().map(AsyncResolver::clone);
+            Either::Left(Box::pin(async move {
+                trace!("DNS resolver: resolving host {:?}", req.host());
+                let resolver = if let Some(resolver) = resolver {
+                    resolver
+                } else {
+                    get_default_resolver()
+                        .await
+                        .expect("Failed to get default resolver")
+                };
+                ResolverFuture::new(req, &resolver).await
+            }))
         }
     }
 }
+
+type LookupIpFuture = Pin<Box<dyn Future<Output = Result<LookupIp, ResolveError>>>>;
 
 #[doc(hidden)]
 /// Resolver future
 pub struct ResolverFuture<T: Address> {
     req: Option<Connect<T>>,
-    lookup: Background<LookupIpFuture>,
+    lookup: LookupIpFuture,
 }
 
 impl<T: Address> ResolverFuture<T> {
     pub fn new(req: Connect<T>, resolver: &AsyncResolver) -> Self {
-        let lookup = if let Some(host) = req.host().splitn(2, ':').next() {
-            resolver.lookup_ip(host)
+        let host = if let Some(host) = req.host().splitn(2, ':').next() {
+            host
         } else {
-            resolver.lookup_ip(req.host())
+            req.host()
         };
 
+        // Clone data to be moved to the lookup future
+        let host_clone = host.to_owned();
+        let resolver_clone = resolver.clone();
+
         ResolverFuture {
-            lookup,
+            lookup: Box::pin(async move {
+                let resolver = resolver_clone;
+                resolver.lookup_ip(host_clone).await
+            }),
             req: Some(req),
         }
     }

--- a/actix-connect/src/service.rs
+++ b/actix-connect/src/service.rs
@@ -6,7 +6,7 @@ use actix_rt::net::TcpStream;
 use actix_service::{Service, ServiceFactory};
 use either::Either;
 use futures::future::{ok, Ready};
-use trust_dns_resolver::AsyncResolver;
+use trust_dns_resolver::TokioAsyncResolver as AsyncResolver;
 
 use crate::connect::{Address, Connect, Connection};
 use crate::connector::{TcpConnector, TcpConnectorFactory};

--- a/actix-connect/src/ssl/openssl.rs
+++ b/actix-connect/src/ssl/openssl.rs
@@ -11,7 +11,7 @@ use actix_codec::{AsyncRead, AsyncWrite};
 use actix_rt::net::TcpStream;
 use actix_service::{Service, ServiceFactory};
 use futures::future::{err, ok, Either, FutureExt, LocalBoxFuture, Ready};
-use trust_dns_resolver::AsyncResolver;
+use trust_dns_resolver::TokioAsyncResolver as AsyncResolver;
 
 use crate::{
     Address, Connect, ConnectError, ConnectService, ConnectServiceFactory, Connection,

--- a/actix-connect/tests/test_connect.rs
+++ b/actix-connect/tests/test_connect.rs
@@ -54,7 +54,7 @@ async fn test_static_str() {
         })
     });
 
-    let resolver = actix_connect::start_default_resolver();
+    let resolver = actix_connect::start_default_resolver().await.unwrap();
     let mut conn = actix_connect::new_connector(resolver.clone());
 
     let con = conn.call(Connect::with("10", srv.addr())).await.unwrap();
@@ -77,7 +77,9 @@ async fn test_new_service() {
     });
 
     let resolver =
-        actix_connect::start_resolver(ResolverConfig::default(), ResolverOpts::default());
+        actix_connect::start_resolver(ResolverConfig::default(), ResolverOpts::default())
+            .await
+            .unwrap();
 
     let factory = actix_connect::new_connector_factory(resolver);
 

--- a/actix-connect/tests/test_connect.rs
+++ b/actix-connect/tests/test_connect.rs
@@ -14,12 +14,10 @@ use actix_connect::Connect;
 #[actix_rt::test]
 async fn test_string() {
     let srv = TestServer::with(|| {
-        fn_service(|io: TcpStream| {
-            async {
-                let mut framed = Framed::new(io, BytesCodec);
-                framed.send(Bytes::from_static(b"test")).await?;
-                Ok::<_, io::Error>(())
-            }
+        fn_service(|io: TcpStream| async {
+            let mut framed = Framed::new(io, BytesCodec);
+            framed.send(Bytes::from_static(b"test")).await?;
+            Ok::<_, io::Error>(())
         })
     });
 
@@ -33,12 +31,10 @@ async fn test_string() {
 #[actix_rt::test]
 async fn test_rustls_string() {
     let srv = TestServer::with(|| {
-        fn_service(|io: TcpStream| {
-            async {
-                let mut framed = Framed::new(io, BytesCodec);
-                framed.send(Bytes::from_static(b"test")).await?;
-                Ok::<_, io::Error>(())
-            }
+        fn_service(|io: TcpStream| async {
+            let mut framed = Framed::new(io, BytesCodec);
+            framed.send(Bytes::from_static(b"test")).await?;
+            Ok::<_, io::Error>(())
         })
     });
 
@@ -51,12 +47,10 @@ async fn test_rustls_string() {
 #[actix_rt::test]
 async fn test_static_str() {
     let srv = TestServer::with(|| {
-        fn_service(|io: TcpStream| {
-            async {
-                let mut framed = Framed::new(io, BytesCodec);
-                framed.send(Bytes::from_static(b"test")).await?;
-                Ok::<_, io::Error>(())
-            }
+        fn_service(|io: TcpStream| async {
+            let mut framed = Framed::new(io, BytesCodec);
+            framed.send(Bytes::from_static(b"test")).await?;
+            Ok::<_, io::Error>(())
         })
     });
 
@@ -75,12 +69,10 @@ async fn test_static_str() {
 #[actix_rt::test]
 async fn test_new_service() {
     let srv = TestServer::with(|| {
-        fn_service(|io: TcpStream| {
-            async {
-                let mut framed = Framed::new(io, BytesCodec);
-                framed.send(Bytes::from_static(b"test")).await?;
-                Ok::<_, io::Error>(())
-            }
+        fn_service(|io: TcpStream| async {
+            let mut framed = Framed::new(io, BytesCodec);
+            framed.send(Bytes::from_static(b"test")).await?;
+            Ok::<_, io::Error>(())
         })
     });
 
@@ -100,12 +92,10 @@ async fn test_uri() {
     use std::convert::TryFrom;
 
     let srv = TestServer::with(|| {
-        fn_service(|io: TcpStream| {
-            async {
-                let mut framed = Framed::new(io, BytesCodec);
-                framed.send(Bytes::from_static(b"test")).await?;
-                Ok::<_, io::Error>(())
-            }
+        fn_service(|io: TcpStream| async {
+            let mut framed = Framed::new(io, BytesCodec);
+            framed.send(Bytes::from_static(b"test")).await?;
+            Ok::<_, io::Error>(())
         })
     });
 
@@ -121,12 +111,10 @@ async fn test_rustls_uri() {
     use std::convert::TryFrom;
 
     let srv = TestServer::with(|| {
-        fn_service(|io: TcpStream| {
-            async {
-                let mut framed = Framed::new(io, BytesCodec);
-                framed.send(Bytes::from_static(b"test")).await?;
-                Ok::<_, io::Error>(())
-            }
+        fn_service(|io: TcpStream| async {
+            let mut framed = Framed::new(io, BytesCodec);
+            framed.send(Bytes::from_static(b"test")).await?;
+            Ok::<_, io::Error>(())
         })
     });
 


### PR DESCRIPTION
- `Address` trait is now required to have static lifetime as it might be used in a returned `Future`;
- `start_resolver` and `start_default_resolver` are now `async` and may return a `ConnectError` as they depend on the new api for `trust_dns_resolver::AsyncResolver`;

closes #101 
closes #81