### PR TITLE
Upload coverage on PRs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,16 +59,15 @@ jobs:
           args: --all --all-features --no-fail-fast -- --nocapture
 
       - name: Generate coverage file
-        if: matrix.version == 'stable' && github.ref == 'refs/heads/master'
+        if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         run: |
           cargo install cargo-tarpaulin
           cargo tarpaulin --out Xml --workspace --all-features
 
       - name: Upload to Codecov
-        if: matrix.version == 'stable' && github.ref == 'refs/heads/master'
+        if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: cobertura.xml
 
       - name: Clear the cargo caches


### PR DESCRIPTION
codecov-action doesn't require tokens anymore so we can accept PRs from fork repos now.