### PR TITLE
actix-rt: Add Arbiter::is_running helper and fix System::is_set doc 

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,7 +2,11 @@
 
 ## [TBD] - [TBD]
 
-- Expose `System::is_set` to check if current system is running
+Added
+
+- Expose `System::is_set` to check if current system has ben started
+
+- Add `Arbiter::is_running` to check if event loop is running
 
 - Add `Arbiter::local_join` associated function to get be able to `await` for spawned futures
 

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -89,6 +89,11 @@ impl Arbiter {
         })
     }
 
+    /// Check if current arbiter is running.
+    pub fn is_running() -> bool {
+        RUNNING.with(|cell| cell.get())
+    }
+
     /// Stop arbiter from continuing it's event loop.
     pub fn stop(&self) {
         let _ = self.sender.unbounded_send(ArbiterCommand::Stop);

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -8,7 +8,10 @@ use std::{fmt, thread};
 
 use futures_channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures_channel::oneshot::{channel, Canceled, Sender};
-use futures_util::{future::{self, Future, FutureExt}, stream::Stream};
+use futures_util::{
+    future::{self, Future, FutureExt},
+    stream::Stream,
+};
 
 use crate::runtime::Runtime;
 use crate::system::System;
@@ -180,8 +183,7 @@ impl Arbiter {
                 // Box the future and push it to the queue, this results in double boxing
                 // because the executor boxes the future again, but works for now
                 Q.with(move |cell| {
-                    cell.borrow_mut()
-                        .push(Pin::from(Box::alloc().init(future)))
+                    cell.borrow_mut().push(Pin::from(Box::alloc().init(future)))
                 });
             }
         });

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -79,7 +79,7 @@ impl System {
         })
     }
 
-    /// Check if current system is running.
+    /// Check if current system is set, i.e., as already been started.
     pub fn is_set() -> bool {
         CURRENT.with(|cell| cell.borrow().is_some())
     }

--- a/actix-rt/tests/integration_tests.rs
+++ b/actix-rt/tests/integration_tests.rs
@@ -1,6 +1,20 @@
 use std::time::{Duration, Instant};
 
 #[test]
+fn start_and_stop() {
+    actix_rt::System::new("start_and_stop").block_on(async move {
+        assert!(
+            actix_rt::Arbiter::is_running(),
+            "System doesn't seem to have started"
+        );
+    });
+    assert!(
+        !actix_rt::Arbiter::is_running(),
+        "System doesn't seem to have stopped"
+    );
+}
+
+#[test]
 fn await_for_timer() {
     let time = Duration::from_secs(2);
     let instant = Instant::now();


### PR DESCRIPTION
The doc for `System::is_set` states:

> Check if current system is running.

Which is not exactly right. This only checks if system is set, i.e., if it has been started at some point. But it will still be true when the system eventually stops. The following test would panic if used with current API.

```Rust
#[test]
fn start_and_stop() {
    actix_rt::System::new("start_and_stop").block_on(async move {
        assert!(
            actix_rt::System::is_set(),
            "System doesn't seem to have started"
        );
    });
    assert!(
        !actix_rt::System::is_set(),
        "System doesn't seem to have stopped"
    );
}
```

Therefore I have updated it's description to represent what it actually menas. I've added `Arbiter::is_running` function to check if event loop is running for the current thread which does work with the test showed here.