### PR TITLE
macros: Bump up to 0.1.2

### DIFF
--- a/actix-macros/CHANGES.md
+++ b/actix-macros/CHANGES.md
@@ -1,0 +1,9 @@
+# CHANGES
+
+## 0.1.2 - 2020-05-18
+
+### Changed
+
+* Forward actix_rt::test arguments to test function [#127]
+
+[#127]: https://github.com/actix/actix-net/pull/127

--- a/actix-macros/Cargo.toml
+++ b/actix-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-macros"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actix runtime macros"
 repository = "https://github.com/actix/actix-net"
@@ -19,5 +19,5 @@ syn = { version = "^1", features = ["full"] }
 [dev-dependencies]
 actix-rt = "1.0"
 
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 trybuild = "1"

--- a/actix-macros/tests/trybuild/main-02-only-async.rs
+++ b/actix-macros/tests/trybuild/main-02-only-async.rs
@@ -1,4 +1,4 @@
 #[actix_rt::main]
 fn main() {
-    futures::future::ready(()).await
+    futures_util::future::ready(()).await
 }

--- a/actix-macros/tests/trybuild/main-02-only-async.stderr
+++ b/actix-macros/tests/trybuild/main-02-only-async.stderr
@@ -9,6 +9,6 @@ error[E0601]: `main` function not found in crate `$CRATE`
   |
 1 | / #[actix_rt::main]
 2 | | fn main() {
-3 | |     futures::future::ready(()).await
+3 | |     futures_util::future::ready(()).await
 4 | | }
   | |_^ consider adding a `main` function to `$DIR/tests/trybuild/main-02-only-async.rs`


### PR DESCRIPTION
Let's release #127, cc @fafhrd91 could you give the publish access on crates.io to the core team?