### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/actix-codec/Cargo.toml
+++ b/actix-codec/Cargo.toml
@@ -24,4 +24,4 @@ futures-sink = { version = "0.3.4", default-features = false }
 tokio = { version = "0.2.4", default-features=false }
 tokio-util = { version = "0.2.0", default-features=false, features=["codec"] }
 log = "0.4"
-pin-project = "0.4.8"
+pin-project = "0.4.17"

--- a/actix-ioframe/Cargo.toml
+++ b/actix-ioframe/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "0.5.3"
 either = "1.5.3"
 futures-sink = { version = "0.3.4", default-features = false }
 futures-core = { version = "0.3.4", default-features = false }
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 log = "0.4"
 
 [dev-dependencies]

--- a/actix-service/Cargo.toml
+++ b/actix-service/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 futures-util = "0.3.1"
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 
 [dev-dependencies]
 actix-rt = "1.0.0"

--- a/actix-service/src/and_then.rs
+++ b/actix-service/src/and_then.rs
@@ -66,7 +66,7 @@ where
     state: State<A, B>,
 }
 
-#[pin_project::pin_project]
+#[pin_project::pin_project(project = StateProj)]
 enum State<A, B>
 where
     A: Service,
@@ -84,13 +84,11 @@ where
 {
     type Output = Result<B::Response, A::Error>;
 
-    #[pin_project::project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.as_mut().project();
 
-        #[project]
         match this.state.as_mut().project() {
-            State::A(fut, b) => match fut.poll(cx)? {
+            StateProj::A(fut, b) => match fut.poll(cx)? {
                 Poll::Ready(res) => {
                     let mut b = b.take().unwrap();
                     this.state.set(State::Empty); // drop fut A
@@ -100,11 +98,11 @@ where
                 }
                 Poll::Pending => Poll::Pending,
             },
-            State::B(fut) => fut.poll(cx).map(|r| {
+            StateProj::B(fut) => fut.poll(cx).map(|r| {
                 this.state.set(State::Empty);
                 r
             }),
-            State::Empty => panic!("future must not be polled after it returned `Poll::Ready`"),
+            StateProj::Empty => panic!("future must not be polled after it returned `Poll::Ready`"),
         }
     }
 }

--- a/actix-service/src/transform.rs
+++ b/actix-service/src/transform.rs
@@ -211,7 +211,7 @@ where
     state: ApplyTransformFutureState<T, S>,
 }
 
-#[pin_project::pin_project]
+#[pin_project::pin_project(project = ApplyTransformFutureStateProj)]
 pub enum ApplyTransformFutureState<T, S>
 where
     S: ServiceFactory,
@@ -228,13 +228,11 @@ where
 {
     type Output = Result<T::Transform, T::InitError>;
 
-    #[pin_project::project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.as_mut().project();
 
-        #[project]
         match this.state.as_mut().project() {
-            ApplyTransformFutureState::A(fut) => match fut.poll(cx)? {
+            ApplyTransformFutureStateProj::A(fut) => match fut.poll(cx)? {
                 Poll::Ready(srv) => {
                     let fut = this.store.0.new_transform(srv);
                     this.state.set(ApplyTransformFutureState::B(fut));
@@ -242,7 +240,7 @@ where
                 }
                 Poll::Pending => Poll::Pending,
             },
-            ApplyTransformFutureState::B(fut) => fut.poll(cx),
+            ApplyTransformFutureStateProj::B(fut) => fut.poll(cx),
         }
     }
 }

--- a/actix-utils/Cargo.toml
+++ b/actix-utils/Cargo.toml
@@ -25,6 +25,6 @@ either = "1.5.3"
 futures-channel = { version = "0.3.4", default-features = false }
 futures-sink = { version = "0.3.4", default-features = false }
 futures-util = { version = "0.3.4", default-features = false }
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 log = "0.4"
 slab = "0.4"


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*
