### PR TITLE
threadpool: Bump up to 0.3.3

### DIFF
--- a/actix-threadpool/CHANGES.md
+++ b/actix-threadpool/CHANGES.md
@@ -1,10 +1,10 @@
 # Changes
 
-## [0.3.3] - 2020-07-03
+## [0.3.3] - 2020-07-14
 
 ### Changed
 
-* Use parking_lot 0.11
+* Update parking_lot to 0.11
 
 ## [0.3.2] - 2020-05-20
 
@@ -18,7 +18,7 @@
 
 ### Changed
 
-* Use parking_lot 0.10
+* Update parking_lot to 0.10
 
 ## [0.3.0] - 2019-12-02
 

--- a/actix-threadpool/Cargo.toml
+++ b/actix-threadpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-threadpool"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actix thread pool for sync code"
 keywords = ["actix", "network", "framework", "async", "futures"]


### PR DESCRIPTION
This drops the use of `parking_lot` v0.10 on the actix crate.