### PR TITLE
Improve bcodec encode performance

### DIFF
--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2020-xx-xx
 * Use `.advance()` instead of `.split_to()`.
 * Upgrade `tokio-util` to `0.3`.
+* Improve `BytesCodec` `.encode()` performance
 
 ## [0.2.0] - 2019-12-10
 

--- a/actix-codec/src/bcodec.rs
+++ b/actix-codec/src/bcodec.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut, Buf};
 use std::io;
 
 use super::{Decoder, Encoder};
@@ -12,9 +12,9 @@ pub struct BytesCodec;
 impl Encoder<Bytes> for BytesCodec {
     type Error = io::Error;
 
+    #[inline]
     fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        dst.reserve(item.len());
-        dst.put(item);
+        dst.extend_from_slice(item.bytes());
         Ok(())
     }
 }


### PR DESCRIPTION
Remove repeat calls to `reverve` method. Stop treating `item`since it has the assured drop. Add the inline attribute because the resulting body is just one line.

The same as https://github.com/ntex-rs/ntex/pull/22