### PR TITLE
rework actix-threadpool

### DIFF
--- a/actix-threadpool/CHANGES.md
+++ b/actix-threadpool/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Rework pool's gut.
+
 ## [0.3.3] - 2020-07-14
 
 ### Changed

--- a/actix-threadpool/Cargo.toml
+++ b/actix-threadpool/Cargo.toml
@@ -24,6 +24,7 @@ jian_rs = { git = "https://github.com/fakeshadow/jian_rs"}
 lazy_static = "1.3"
 log = "0.4"
 num_cpus = "1.10"
+parking_lot = "0.11.0"
 
 [dev-dependencies]
 actix-rt = "1"

--- a/actix-threadpool/Cargo.toml
+++ b/actix-threadpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-threadpool"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actix thread pool for sync code"
 keywords = ["actix", "network", "framework", "async", "futures"]
@@ -20,8 +20,10 @@ path = "src/lib.rs"
 [dependencies]
 derive_more = "0.99.2"
 futures-channel = "0.3.1"
-parking_lot = "0.11"
+jian_rs = { git = "https://github.com/fakeshadow/jian_rs"}
 lazy_static = "1.3"
 log = "0.4"
 num_cpus = "1.10"
-threadpool = "1.7"
+
+[dev-dependencies]
+actix-rt = "1"

--- a/actix-threadpool/tests/test_thread_pool.rs
+++ b/actix-threadpool/tests/test_thread_pool.rs
@@ -1,0 +1,21 @@
+#[actix_rt::test]
+async fn async_work() {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use core::time::Duration;
+
+    use std::sync::Arc;
+
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    for _ in 0..1024 {
+        let counter = counter.clone();
+        let _ = actix_threadpool::run(move || {
+            counter.fetch_add(1, Ordering::Release);
+            std::thread::sleep(Duration::from_millis(1));
+            Ok::<(), ()>(())
+        })
+        .await;
+    }
+
+    assert_eq!(1024, counter.load(Ordering::Acquire));
+}


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

`actix-threadpool` would spawn a fixed number of threads in a static pool and stay for the life of whole actix-app lifetime. I feel this is an overkill for majority use case and may bring up confusion.

This PR reworks the pool to use a dynamic strategy with the following behavior:
- Rename the worker thread name from "actix-web" to "actix-threadpool-worker".
- Start with 1 idle thread and when more jobs goes in it spawn more threads until hitting the upper limit.
- Any pool thread kept idle for 5 minutes would de spawn it self.

This PR is still not complete and need some help on tests and benchmarks.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->