### PR TITLE
assert workers greater than zero

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+### Changed
+
+* workers(0) defaults to num_cpus::get()
+
 ## [1.0.3] - 2020-05-19
 
 ### Changed

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* workers(0) defaults to num_cpus::get()
+* workers must be greater than 0
 
 ## [1.0.3] - 2020-05-19
 

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -74,10 +74,8 @@ impl ServerBuilder {
     /// By default server uses number of available logical cpu as workers
     /// count. Explicitly setting 0 will also default.
     pub fn workers(mut self, num: usize) -> Self {
-        self.threads = match num {
-            0 => num_cpus::get(),
-            _ => num,
-        };
+        assert_ne!(num 0, "workers must be greater than 0");
+        self.threads = num;
         self
     }
 

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -72,9 +72,12 @@ impl ServerBuilder {
     /// Set number of workers to start.
     ///
     /// By default server uses number of available logical cpu as workers
-    /// count.
+    /// count. Explicitly setting 0 will also default.
     pub fn workers(mut self, num: usize) -> Self {
-        self.threads = num;
+        self.threads = match num {
+            0 => num_cpus::get(),
+            _ => num,
+        };
         self
     }
 

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -72,9 +72,9 @@ impl ServerBuilder {
     /// Set number of workers to start.
     ///
     /// By default server uses number of available logical cpu as workers
-    /// count. Explicitly setting 0 will also default.
+    /// count. Workers must be greater than 0.
     pub fn workers(mut self, num: usize) -> Self {
-        assert_ne!(num 0, "workers must be greater than 0");
+        assert_ne!(num, 0, "workers must be greater than 0");
         self.threads = num;
         self
     }


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
Check your PR fulfills the following:

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Before setting workers(0) will actually spin 0 threads. With this change, when setting 0 it defaults back to available logical cpus using num_cpus::get(). Use case, is having a configuration system which might request the default value and can do this by passing 0 as the worker parameter.

Closes #166 