### PR TITLE
Remove garbled doc comment for actix_router::IntoPattern::is_single

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -37,7 +37,6 @@ impl ResourcePath for bytestring::ByteString {
 
 /// Helper trait for type that could be converted to path pattern
 pub trait IntoPattern {
-    /// Signle patter
     fn is_single(&self) -> bool;
 
     fn patterns(&self) -> Vec<String>;


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
I noticed the doc comment for `actix_router::IntoPattern::is_single` was typo'd.

It was probably meant to be "Single pattern", but since the method seems self-documenting enough I just removed it. Please let me know if you'd prefer something else!

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
