### PR TITLE
GHA: Switch action to the official setup-msys2

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -31,12 +31,12 @@ jobs:
           override: true
 
       - name: Install MSYS2
-        uses: numworks/setup-msys2@v1
+        uses: msys2/setup-msys2@v2
 
       - name: Install packages
         run: |
-          msys2do pacman -Sy --noconfirm pacman
-          msys2do pacman --noconfirm -S base-devel pkg-config
+          msys2 -c 'pacman -Sy --noconfirm pacman'
+          msys2 -c 'pacman --noconfirm -S base-devel pkg-config'
 
       - name: check build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
MSYS2 now has their own action. And GHA has changed their default branch to `main` so `master` is now outdated, change it to v2.