### PR TITLE
Fix CI on MSRV check

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Generate coverage file
         if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         run: |
-          which cargo-tarpaulin || cargo install cargo-tarpaulin
+          cargo install cargo-tarpaulin
           cargo tarpaulin --out Xml --workspace --all-features
 
       - name: Upload to Codecov
@@ -76,5 +76,7 @@ jobs:
 
       - name: Clear the cargo caches
         run: |
-          which cargo-cache || cargo install cargo-cache --no-default-features --features ci-autoclean
+          rustup update stable
+          rustup override set stable
+          cargo install cargo-cache --no-default-features --features ci-autoclean
           cargo-cache


### PR DESCRIPTION
For instance: https://github.com/actix/actix-net/runs/940187979

This is because we use 1.39.0 for installing cargo-cache, it should be resolved by using the latest stable instead.