### PR TITLE
actix-rt: Make the process of running System in existing Runtime more clear

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased - 2020-xx-xx
+
+### Added
+
+* Add `System::attach_to_tokio` method. [#173]
+
 ## [1.1.1] - 2020-04-30
 
 ### Fixed

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -25,5 +25,4 @@ smallvec = "1"
 tokio = { version = "0.2.6", default-features = false, features = ["rt-core", "rt-util", "io-driver", "tcp", "uds", "udp", "time", "signal", "stream"] }
 
 [dev-dependencies]
-futures = "0.3"
 tokio = { version = "0.2.6", features = ["full"] }

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -23,3 +23,7 @@ futures-util = { version = "0.3.4", default-features = false, features = ["alloc
 copyless = "0.1.4"
 smallvec = "1"
 tokio = { version = "0.2.6", default-features = false, features = ["rt-core", "rt-util", "io-driver", "tcp", "uds", "udp", "time", "signal", "stream"] }
+
+[dev-dependencies]
+futures = "0.3"
+tokio = { version = "0.2.6", features = ["full"] }

--- a/actix-rt/src/builder.rs
+++ b/actix-rt/src/builder.rs
@@ -137,7 +137,7 @@ impl AsyncSystemRunner {
                     Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
                 };
                 Arbiter::stop_system();
-                return res;
+                res
             }
         })
         .flatten()

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -57,10 +57,58 @@ impl System {
         Self::builder().name(name).build()
     }
 
-    #[allow(clippy::new_ret_no_self)]
-    /// Create new system using provided tokio Handle.
+    /// Create new system using provided tokio `LocalSet`.
     ///
     /// This method panics if it can not spawn system arbiter
+    ///
+    /// Note: This method uses provided `LocalSet` to create a `System` future only.
+    /// All the [`Arbiter`]s will be started in separate threads using their own tokio `Runtime`s.
+    /// It means that using this method currently it is impossible to make `actix-rt` work in the `Runtime` other
+    /// than the provided by `tokio` 0.2 (e.g. provided by `tokio_compat`).
+    ///
+    /// [`Arbiter`]: struct.Arbiter.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::{runtime::Runtime, task::LocalSet};
+    /// use actix_rt::System;
+    /// use futures::future::try_join_all;
+    ///
+    /// async fn run_application() {
+    ///     let first_task = tokio::spawn(async {
+    ///         // ...
+    /// #        println!("One task");
+    /// #        Ok::<(),()>(())
+    ///     });
+    ///
+    ///     let second_task = tokio::spawn(async {
+    ///         // ...
+    /// #       println!("Another task");
+    /// #       Ok::<(),()>(())
+    ///     });
+    ///
+    ///     try_join_all(vec![first_task, second_task])
+    ///         .await
+    ///         .expect("Some of the futures finished unexpectedly");
+    /// }
+    ///
+    ///
+    /// let mut runtime = tokio::runtime::Builder::new()
+    ///     .core_threads(2)
+    ///     .enable_all()
+    ///     .threaded_scheduler()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    ///
+    /// let actix_system_task = LocalSet::new();
+    /// let sys = System::run_in_tokio("actix-main-system", &actix_system_task);
+    /// actix_system_task.spawn_local(sys);
+    ///
+    /// let rest_operations = run_application();
+    /// runtime.block_on(actix_system_task.run_until(rest_operations));
+    /// ```
     pub fn run_in_tokio<T: Into<String>>(
         name: T,
         local: &LocalSet,
@@ -69,6 +117,76 @@ impl System {
             .name(name)
             .build_async(local)
             .run_nonblocking()
+    }
+
+    /// Consume the provided tokio Runtime and start the `System` in it.
+    /// This method will create a `LocalSet` object and occupy the current thread
+    /// for the created `System` exclusively. All the other asynchronous tasks that
+    /// should be executed as well must be aggregated into one future, provided as the last
+    /// argument to this method.
+    ///
+    /// Note: This method uses provided `Runtime` to create a `System` future only.
+    /// All the [`Arbiter`]s will be started in separate threads using their own tokio `Runtime`s.
+    /// It means that using this method currently it is impossible to make `actix-rt` work in the
+    /// `Runtime` other than the provided by `tokio` 0.2 (e.g. provided by `tokio_compat`).
+    ///
+    /// [`Arbiter`]: struct.Arbiter.html
+    ///
+    /// # Arguments
+    ///
+    /// - `runtime`: A tokio Runtime to run the system in.
+    /// - `name`: Name of the System
+    /// - `rest_operations`: A future to be executed in the runtime along with the System.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime::Runtime;
+    /// use actix_rt::System;
+    /// use futures::future::try_join_all;
+    ///
+    /// async fn run_application() {
+    ///     let first_task = tokio::spawn(async {
+    ///         // ...
+    /// #        println!("One task");
+    /// #        Ok::<(),()>(())
+    ///     });
+    ///
+    ///     let second_task = tokio::spawn(async {
+    ///         // ...
+    /// #       println!("Another task");
+    /// #       Ok::<(),()>(())
+    ///     });
+    ///
+    ///     try_join_all(vec![first_task, second_task])
+    ///         .await
+    ///         .expect("Some of the futures finished unexpectedly");
+    /// }
+    ///
+    ///
+    /// let runtime = tokio::runtime::Builder::new()
+    ///     .core_threads(2)
+    ///     .enable_all()
+    ///     .threaded_scheduler()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let rest_operations = run_application();
+    /// System::attach_to_tokio(runtime, "actix-main-system", rest_operations);
+    /// ```
+    pub fn attach_to_tokio<Fut, R>(
+        mut runtime: tokio::runtime::Runtime,
+        name: impl Into<String>,
+        rest_operations: Fut,
+    ) -> R
+    where
+        Fut: std::future::Future<Output = R>,
+    {
+        let actix_system_task = LocalSet::new();
+        let sys = System::run_in_tokio(name.into(), &actix_system_task);
+        actix_system_task.spawn_local(sys);
+
+        runtime.block_on(actix_system_task.run_until(rest_operations))
     }
 
     /// Get current running system.

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -63,17 +63,18 @@ impl System {
     ///
     /// Note: This method uses provided `LocalSet` to create a `System` future only.
     /// All the [`Arbiter`]s will be started in separate threads using their own tokio `Runtime`s.
-    /// It means that using this method currently it is impossible to make `actix-rt` work in the `Runtime` other
-    /// than the provided by `tokio` 0.2 (e.g. provided by `tokio_compat`).
+    /// It means that using this method currently it is impossible to make `actix-rt` work in the
+    /// alternative `tokio` `Runtime`s (e.g. provided by [`tokio_compat`]).
     ///
     /// [`Arbiter`]: struct.Arbiter.html
+    /// [`tokio_compat`]: https://crates.io/crates/tokio-compat
     ///
     /// # Examples
     ///
     /// ```
     /// use tokio::{runtime::Runtime, task::LocalSet};
     /// use actix_rt::System;
-    /// use futures::future::try_join_all;
+    /// use futures_util::future::try_join_all;
     ///
     /// async fn run_application() {
     ///     let first_task = tokio::spawn(async {
@@ -128,14 +129,15 @@ impl System {
     /// Note: This method uses provided `Runtime` to create a `System` future only.
     /// All the [`Arbiter`]s will be started in separate threads using their own tokio `Runtime`s.
     /// It means that using this method currently it is impossible to make `actix-rt` work in the
-    /// `Runtime` other than the provided by `tokio` 0.2 (e.g. provided by `tokio_compat`).
+    /// alternative `tokio` `Runtime`s (e.g. provided by `tokio_compat`).
     ///
     /// [`Arbiter`]: struct.Arbiter.html
+    /// [`tokio_compat`]: https://crates.io/crates/tokio-compat
     ///
     /// # Arguments
     ///
-    /// - `runtime`: A tokio Runtime to run the system in.
     /// - `name`: Name of the System
+    /// - `runtime`: A tokio Runtime to run the system in.
     /// - `rest_operations`: A future to be executed in the runtime along with the System.
     ///
     /// # Examples
@@ -143,7 +145,7 @@ impl System {
     /// ```
     /// use tokio::runtime::Runtime;
     /// use actix_rt::System;
-    /// use futures::future::try_join_all;
+    /// use futures_util::future::try_join_all;
     ///
     /// async fn run_application() {
     ///     let first_task = tokio::spawn(async {
@@ -172,11 +174,11 @@ impl System {
     ///     .unwrap();
     ///
     /// let rest_operations = run_application();
-    /// System::attach_to_tokio(runtime, "actix-main-system", rest_operations);
+    /// System::attach_to_tokio("actix-main-system", runtime, rest_operations);
     /// ```
     pub fn attach_to_tokio<Fut, R>(
-        mut runtime: tokio::runtime::Runtime,
         name: impl Into<String>,
+        mut runtime: tokio::runtime::Runtime,
         rest_operations: Fut,
     ) -> R
     where


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other (Usability enhancement)


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

When I first tried to start the `actix-web` server using an existing `tokio` `Runtime`, I honestly found the interface a bit unfriendly.

In an attempt to make other folks' life easier I did the following:

- Added doc-comments with an example and a note about `Arbiter`s still using their own `Runtime` objects.
- Added a new method which is less flexible but simpler to use to attach a `System` to a given `Runtime`.

These changes aren't breaking and hopefully useful.

