### PR TITLE
actix-service: Fix clippy warning in benches

### DIFF
--- a/actix-service/benches/and_then.rs
+++ b/actix-service/benches/and_then.rs
@@ -293,9 +293,8 @@ where
             let start = std::time::Instant::now();
             // benchmark body
             rt.block_on(async move { join_all(srvs.iter_mut().map(|srv| srv.call(()))).await });
-            let elapsed = start.elapsed();
             // check that at least first request succeeded
-            elapsed
+            start.elapsed()
         })
     });
 }

--- a/actix-service/benches/unsafecell_vs_refcell.rs
+++ b/actix-service/benches/unsafecell_vs_refcell.rs
@@ -95,9 +95,8 @@ where
             let start = std::time::Instant::now();
             // benchmark body
             rt.block_on(async move { join_all(srvs.iter_mut().map(|srv| srv.call(()))).await });
-            let elapsed = start.elapsed();
             // check that at least first request succeeded
-            elapsed
+            start.elapsed()
         })
     });
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Currently benches code for `actix-service` emits a `clippy::let_and_return` warning. This minor PR fixes it.
