### PR TITLE
solve framed integration with actix-http

### DIFF
--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -5,6 +5,9 @@
 * Upgrade `tokio-util` to `0.3`.
 * Improve `BytesCodec` `.encode()` performance
 * Simplify `BytesCodec` `.decode()` 
+* Rename methods on `Framed` to better describe their use.
+* Add method on `Framed` to get a pinned reference to the underlying I/O.
+* Add method on `Framed` check emptiness of read buffer.
 
 ## [0.2.0] - 2019-12-10
 

--- a/actix-codec/src/lib.rs
+++ b/actix-codec/src/lib.rs
@@ -8,7 +8,9 @@
 //! [`AsyncWrite`]: AsyncWrite
 //! [`Sink`]: futures_sink::Sink
 //! [`Stream`]: futures_core::Stream
+
 #![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
 
 mod bcodec;
 mod framed;

--- a/actix-utils/CHANGES.md
+++ b/actix-utils/CHANGES.md
@@ -4,8 +4,7 @@
 
 * Upgrade `tokio-util` to `0.3`.
 * Remove unsound custom Cell and use `std::cell::RefCell` instead, as well as `actix-service`.
-* Provide correctly spelled `LocalWaker::is_registered` method and deprecate the replaced.
-* Alias `framed` module as `dispatcher`.
+* Rename method to correctly spelled `LocalWaker::is_registered`.
 
 ## [1.0.6] - 2020-01-08
 

--- a/actix-utils/CHANGES.md
+++ b/actix-utils/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Upgrade `tokio-util` to `0.3`.
 * Remove unsound custom Cell and use `std::cell::RefCell` instead, as well as `actix-service`.
+* Provide correctly spelled `LocalWaker::is_registered` method and deprecate the replaced.
+* Alias `framed` module as `dispatcher`.
 
 ## [1.0.6] - 2020-01-08
 

--- a/actix-utils/src/counter.rs
+++ b/actix-utils/src/counter.rs
@@ -7,7 +7,7 @@ use crate::task::LocalWaker;
 #[derive(Clone)]
 /// Simple counter with ability to notify task on reaching specific number
 ///
-/// Counter could be cloned, total ncount is shared across all clones.
+/// Counter could be cloned, total n-count is shared across all clones.
 pub struct Counter(Rc<CounterInner>);
 
 struct CounterInner {

--- a/actix-utils/src/dispatcher.rs
+++ b/actix-utils/src/dispatcher.rs
@@ -1,5 +1,7 @@
 //! Framed dispatcher service and related utilities
+
 #![allow(type_alias_bounds)]
+
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{fmt, mem};

--- a/actix-utils/src/inflight.rs
+++ b/actix-utils/src/inflight.rs
@@ -152,7 +152,7 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn test_newtransform() {
+    async fn test_new_transform() {
         let wait_time = Duration::from_millis(50);
 
         let srv = apply(InFlight::new(1), fn_factory(|| ok(SleepService(wait_time))));

--- a/actix-utils/src/lib.rs
+++ b/actix-utils/src/lib.rs
@@ -1,11 +1,12 @@
 //! Actix utils - various helper services
+
 #![deny(rust_2018_idioms)]
 #![allow(clippy::type_complexity)]
 
 pub mod condition;
 pub mod counter;
+pub mod dispatcher;
 pub mod either;
-pub mod framed;
 pub mod inflight;
 pub mod keepalive;
 pub mod mpsc;
@@ -15,3 +16,5 @@ pub mod stream;
 pub mod task;
 pub mod time;
 pub mod timeout;
+
+pub use dispatcher as framed;

--- a/actix-utils/src/lib.rs
+++ b/actix-utils/src/lib.rs
@@ -16,5 +16,3 @@ pub mod stream;
 pub mod task;
 pub mod time;
 pub mod timeout;
-
-pub use dispatcher as framed;

--- a/actix-utils/src/oneshot.rs
+++ b/actix-utils/src/oneshot.rs
@@ -170,7 +170,7 @@ pub struct PReceiver<T> {
     inner: Rc<RefCell<Slab<PoolInner<T>>>>,
 }
 
-// The oneshots do not ever project Pin to the inner T
+// The one-shots do not ever project Pin to the inner T
 impl<T> Unpin for PReceiver<T> {}
 impl<T> Unpin for PSender<T> {}
 

--- a/actix-utils/src/order.rs
+++ b/actix-utils/src/order.rs
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn test_inorder() {
+    async fn test_in_order() {
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
         let (tx3, rx3) = oneshot::channel();

--- a/actix-utils/src/task.rs
+++ b/actix-utils/src/task.rs
@@ -34,15 +34,6 @@ impl LocalWaker {
         }
     }
 
-    #[deprecated(
-        note = "Use correctly spelled `is_registered` method. Removal scheduled for v2.0."
-    )]
-    #[inline]
-    /// Check if waker has been registered.
-    pub fn is_registed(&self) -> bool {
-        self.is_registered()
-    }
-
     #[inline]
     /// Check if waker has been registered.
     pub fn is_registered(&self) -> bool {

--- a/actix-utils/src/task.rs
+++ b/actix-utils/src/task.rs
@@ -34,9 +34,18 @@ impl LocalWaker {
         }
     }
 
+    #[deprecated(
+        note = "Use correctly spelled `is_registered` method. Removal scheduled for v2.0."
+    )]
     #[inline]
     /// Check if waker has been registered.
     pub fn is_registed(&self) -> bool {
+        self.is_registered()
+    }
+
+    #[inline]
+    /// Check if waker has been registered.
+    pub fn is_registered(&self) -> bool {
         unsafe { (*self.waker.get()).is_some() }
     }
 

--- a/actix-utils/src/time.rs
+++ b/actix-utils/src/time.rs
@@ -173,7 +173,7 @@ mod tests {
     ///
     /// Expected Behavior: Two back-to-back calls of `LowResTimeService::now()` return the same value.
     #[actix_rt::test]
-    async fn lowres_time_service_time_does_not_immediately_change() {
+    async fn low_res_time_service_time_does_not_immediately_change() {
         let resolution = Duration::from_millis(50);
         let time_service = LowResTimeService::with(resolution);
         assert_eq!(time_service.now(), time_service.now());
@@ -210,7 +210,7 @@ mod tests {
     /// Expected Behavior: Two calls of `LowResTimeService::now()` made in subsequent resolution interval return different values
     /// and second value is greater than the first one at least by a resolution interval.
     #[actix_rt::test]
-    async fn lowres_time_service_time_updates_after_resolution_interval() {
+    async fn low_res_time_service_time_updates_after_resolution_interval() {
         let resolution = Duration::from_millis(100);
         let wait_time = Duration::from_millis(300);
         let time_service = LowResTimeService::with(resolution);

--- a/actix-utils/src/timeout.rs
+++ b/actix-utils/src/timeout.rs
@@ -220,7 +220,7 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn test_timeout_newservice() {
+    async fn test_timeout_new_service() {
         let resolution = Duration::from_millis(100);
         let wait_time = Duration::from_millis(500);
 


### PR DESCRIPTION
## PR Type
Bug Fix / Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
- Follow up #138 and #110.
- Primarily, changes made to `Framed` while attempting integration with `actix-http`.
- Renames some methods to better describe their use.
- Adds a method to get a pinned reference to the framed IO.
- Fix things that were setting off my spell checker.

## Breaking Changes
- Many. But a major bump was already necessary for codec and utils from #138.

Quick note: will address checklist as we go but this should probably be considered in tandem with actix/actix-web#1634