### PR TITLE
remove unused type parameter from Framed::replace_codec

### DIFF
--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased - 2020-xx-xx
 
+## 0.3.0-beta.2 - 2020-08-19
+* Remove unused type parameter from `Framed::replace_codec`.
+
 ## 0.3.0-beta.1 - 2020-08-19
 * Use `.advance()` instead of `.split_to()`.
 * Upgrade `tokio-util` to `0.3`.

--- a/actix-codec/Cargo.toml
+++ b/actix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-codec"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Utilities for encoding and decoding frames"
 keywords = ["network", "framework", "async", "futures"]

--- a/actix-codec/src/framed.rs
+++ b/actix-codec/src/framed.rs
@@ -117,7 +117,7 @@ impl<T, U> Framed<T, U> {
     }
 
     /// Consume the `Frame`, returning `Frame` with different codec.
-    pub fn replace_codec<U2, I2>(self, codec: U2) -> Framed<T, U2> {
+    pub fn replace_codec<U2>(self, codec: U2) -> Framed<T, U2> {
         Framed {
             codec,
             io: self.io,

--- a/actix-connect/Cargo.toml
+++ b/actix-connect/Cargo.toml
@@ -32,7 +32,7 @@ uri = ["http"]
 
 [dependencies]
 actix-service = "1.0.3"
-actix-codec = "0.2.0"
+actix-codec = "0.3.0-beta.2"
 actix-utils = "1.0.6"
 actix-rt = "1.0.0"
 derive_more = "0.99.2"

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 [dependencies]
 actix-service = "1.0.1"
 actix-rt = "1.0.0"
-actix-codec = "0.2.0"
+actix-codec = "0.3.0-beta.2"
 actix-utils = "1.0.4"
 
 log = "0.4"

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -33,7 +33,7 @@ nativetls = ["native-tls", "tokio-tls"]
 
 [dependencies]
 actix-service = "1.0.0"
-actix-codec = "0.2.0"
+actix-codec = "0.3.0-beta.2"
 actix-utils = "1.0.0"
 actix-rt = "1.0.0"
 derive_more = "0.99.2"

--- a/actix-utils/Cargo.toml
+++ b/actix-utils/Cargo.toml
@@ -16,7 +16,7 @@ name = "actix_utils"
 path = "src/lib.rs"
 
 [dependencies]
-actix-codec = "0.3.0-beta.1"
+actix-codec = "0.3.0-beta.2"
 actix-rt = "1.1.1"
 actix-service = "1.0.6"
 bitflags = "1.2.1"


### PR DESCRIPTION
## PR Type
Chore


## PR Checklist
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
As in title, the I2 param is not used. Also prepares beta 2 release.
