### PR TITLE
prepare tls v2 release

### DIFF
--- a/actix-connect/CHANGES.md
+++ b/actix-connect/CHANGES.md
@@ -1,7 +1,10 @@
 # Changes
 
-## Unreleased
+## Unreleased - 2020-xx-xx
 
+
+## 2.0.0 - 2020-09-02
+- No significant changes from `2.0.0-alpha.4`.
 
 ## 2.0.0-alpha.4 - 2020-08-17
 

--- a/actix-connect/src/lib.rs
+++ b/actix-connect/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! ## Package feature
 //!
-//! * `openssl` - enables ssl support via `openssl` crate
-//! * `rustls` - enables ssl support via `rustls` crate
+//! * `openssl` - enables TLS support via `openssl` crate
+//! * `rustls` - enables TLS support via `rustls` crate
 
 #![deny(rust_2018_idioms)]
 #![recursion_limit = "128"]

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -1,39 +1,37 @@
 # Changes
 
-## Unreleased
+## Unreleased - 2020-xx-xx
+
+
+## 2.0.0 - 2020-09-03
+* `nativetls::NativeTlsAcceptor` is renamed to `nativetls::Acceptor`.
+* Where possible, "SSL" terminology is replaced with "TLS".
+    * `SslError` is renamed to `TlsError`.
+    * `TlsError::Ssl` enum variant is renamed to `TlsError::Tls`.
+    * `max_concurrent_ssl_connect` is renamed to `max_concurrent_tls_connect`.
 
 
 ## 2.0.0-alpha.2 - 2020-08-17
-
-### Changed
-
 * Update `rustls` dependency to 0.18
 * Update `tokio-rustls` dependency to 0.14
 * Update `webpki-roots` dependency to 0.20
 
 
 ## [2.0.0-alpha.1] - 2020-03-03
-
-### Changed
-
 * Update `rustls` dependency to 0.17
 * Update `tokio-rustls` dependency to 0.13
 * Update `webpki-roots` dependency to 0.19
 
-## [1.0.0] - 2019-12-11
 
+## [1.0.0] - 2019-12-11
 * 1.0.0 release
 
+
 ## [1.0.0-alpha.3] - 2019-12-07
-
-### Changed
-
 * Migrate to tokio 0.2
-
 * Enable rustls acceptor service
-
 * Enable native-tls acceptor service
 
-## [1.0.0-alpha.1] - 2019-12-02
 
-* Split openssl accetor from actix-server package
+## [1.0.0-alpha.1] - 2019-12-02
+* Split openssl acceptor from actix-server package

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "actix-tls"
-version = "2.0.0-alpha.2"
+version = "2.0.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
-description = "Actix tls services"
-keywords = ["network", "framework", "async", "futures"]
+description = "TLS acceptor services for Actix ecosystem."
+keywords = ["network", "framework", "async", "futures", "tls", "ssl"]
 homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-net.git"
 documentation = "https://docs.rs/actix-tls/"
 categories = ["network-programming", "asynchronous"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
-workspace = ".."
 
 [package.metadata.docs.rs]
 features = ["openssl", "rustls", "nativetls"]
@@ -35,26 +34,23 @@ nativetls = ["native-tls", "tokio-tls"]
 actix-service = "1.0.0"
 actix-codec = "0.3.0"
 actix-utils = "2.0.0"
-actix-rt = "1.0.0"
-derive_more = "0.99.2"
-either = "1.5.2"
+
 futures-util = { version = "0.3.4", default-features = false }
-log = "0.4"
 
 # openssl
-open-ssl = { version="0.10", package = "openssl", optional = true }
+open-ssl = { package = "openssl", version = "0.10", optional = true }
 tokio-openssl = { version = "0.4.0", optional = true }
 
 # rustls
-rust-tls = { version = "0.18.0", package = "rustls", optional = true }
+rust-tls = { package = "rustls", version = "0.18.0", optional = true }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.20", optional = true }
 tokio-rustls = { version = "0.14.0", optional = true }
 
 # native-tls
-native-tls = { version="0.2", optional = true }
-tokio-tls = { version="0.3", optional = true }
+native-tls = { version = "0.2", optional = true }
+tokio-tls = { version = "0.3", optional = true }
 
 [dev-dependencies]
 bytes = "0.5"
-actix-testing = { version="1.0.0" }
+actix-testing = { version = "1.0.0" }

--- a/actix-tls/src/lib.rs
+++ b/actix-tls/src/lib.rs
@@ -1,6 +1,11 @@
-//! SSL Services
-#![deny(rust_2018_idioms, warnings)]
-#![allow(clippy::type_complexity)]
+//! TLS acceptor services for Actix ecosystem.
+//!
+//! ## Crate Features
+//! * `openssl` - TLS acceptor using the `openssl` crate.
+//! * `rustls` - TLS acceptor using the `rustls` crate.
+//! * `nativetls` - TLS acceptor using the `native-tls` crate.
+
+#![deny(rust_2018_idioms)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -15,25 +20,25 @@ pub mod rustls;
 #[cfg(feature = "nativetls")]
 pub mod nativetls;
 
-/// Sets the maximum per-worker concurrent ssl connection establish process.
-///
-/// All listeners will stop accepting connections when this limit is
-/// reached. It can be used to limit the global SSL CPU usage.
-///
-/// By default max connections is set to a 256.
-pub fn max_concurrent_ssl_connect(num: usize) {
-    MAX_CONN.store(num, Ordering::Relaxed);
-}
-
 pub(crate) static MAX_CONN: AtomicUsize = AtomicUsize::new(256);
 
 thread_local! {
     static MAX_CONN_COUNTER: Counter = Counter::new(MAX_CONN.load(Ordering::Relaxed));
 }
 
-/// Ssl error combinded with service error.
+/// Sets the maximum per-worker concurrent TLS connection limit.
+///
+/// All listeners will stop accepting connections when this limit is reached.
+/// It can be used to regulate the global TLS CPU usage.
+///
+/// By default, the connection limit is 256.
+pub fn max_concurrent_tls_connect(num: usize) {
+    MAX_CONN.store(num, Ordering::Relaxed);
+}
+
+/// TLS error combined with service error.
 #[derive(Debug)]
-pub enum SslError<E1, E2> {
-    Ssl(E1),
+pub enum TlsError<E1, E2> {
+    Tls(E1),
     Service(E2),
 }

--- a/actix-tls/src/openssl.rs
+++ b/actix-tls/src/openssl.rs
@@ -3,26 +3,27 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-pub use open_ssl::ssl::{AlpnError, SslAcceptor, SslAcceptorBuilder};
-pub use tokio_openssl::{HandshakeError, SslStream};
-
 use actix_codec::{AsyncRead, AsyncWrite};
 use actix_service::{Service, ServiceFactory};
 use actix_utils::counter::{Counter, CounterGuard};
 use futures_util::future::{ok, FutureExt, LocalBoxFuture, Ready};
 
+pub use open_ssl::ssl::{AlpnError, SslAcceptor, SslAcceptorBuilder};
+pub use tokio_openssl::{HandshakeError, SslStream};
+
 use crate::MAX_CONN_COUNTER;
 
-/// Support `TLS` server connections via openssl package
+/// Accept TLS connections via `openssl` package.
 ///
-/// `openssl` feature enables `Acceptor` type
+/// `openssl` feature enables this `Acceptor` type.
 pub struct Acceptor<T: AsyncRead + AsyncWrite> {
     acceptor: SslAcceptor,
     io: PhantomData<T>,
 }
 
 impl<T: AsyncRead + AsyncWrite> Acceptor<T> {
-    /// Create default `OpensslAcceptor`
+    /// Create OpenSSL based `Acceptor` service factory.
+    #[inline]
     pub fn new(acceptor: SslAcceptor) -> Self {
         Acceptor {
             acceptor,
@@ -32,6 +33,7 @@ impl<T: AsyncRead + AsyncWrite> Acceptor<T> {
 }
 
 impl<T: AsyncRead + AsyncWrite> Clone for Acceptor<T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             acceptor: self.acceptor.clone(),

--- a/actix-tls/src/rustls.rs
+++ b/actix-tls/src/rustls.rs
@@ -17,16 +17,17 @@ pub use webpki_roots::TLS_SERVER_ROOTS;
 
 use crate::MAX_CONN_COUNTER;
 
-/// Support `SSL` connections via rustls package
+/// Accept TLS connections via `rustls` package.
 ///
-/// `rust-tls` feature enables `RustlsAcceptor` type
+/// `rustls` feature enables this `Acceptor` type.
 pub struct Acceptor<T> {
     config: Arc<ServerConfig>,
     io: PhantomData<T>,
 }
 
 impl<T: AsyncRead + AsyncWrite> Acceptor<T> {
-    /// Create rustls based `Acceptor` service factory
+    /// Create Rustls based `Acceptor` service factory.
+    #[inline]
     pub fn new(config: ServerConfig) -> Self {
         Acceptor {
             config: Arc::new(config),
@@ -36,6 +37,7 @@ impl<T: AsyncRead + AsyncWrite> Acceptor<T> {
 }
 
 impl<T> Clone for Acceptor<T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             config: self.config.clone(),
@@ -65,7 +67,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> ServiceFactory for Acceptor<T> {
     }
 }
 
-/// RusTLS based `Acceptor` service
+/// Rustls based `Acceptor` service
 pub struct AcceptorService<T> {
     acceptor: TlsAcceptor,
     io: PhantomData<T>,


### PR DESCRIPTION
Renamed a few things to move SSL nomenclature over to TLS.

Actix web/http/awc is the only thing depending on this crate so breaking changes are more than managable.