### PR TITLE
prepare server release 1.0.4

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -1,216 +1,128 @@
 # Changes
 
-## Unreleased
+## Unreleased - 2020-xx-xx
 
-### Changed
 
-* workers must be greater than 0
+## 1.0.4 - 2020-09-12
+* Update actix-codec to 0.3.0.
+* Workers must be greater than 0. [#167]
 
-## [1.0.3] - 2020-05-19
+[#167]: https://github.com/actix/actix-net/pull/167
 
-### Changed
 
+## 1.0.3 - 2020-05-19
 * Replace deprecated `net2` crate with `socket2` [#140]
 
 [#140]: https://github.com/actix/actix-net/pull/140
 
-## [1.0.2] - 2020-02-26
 
-### Fixed
-
+## 1.0.2 - 2020-02-26
 * Avoid error by calling `reregister()` on Windows [#103]
 
 [#103]: https://github.com/actix/actix-net/pull/103
 
-## [1.0.1] - 2019-12-29
 
-### Changed
-
+## 1.0.1 - 2019-12-29
 * Rename `.start()` method to `.run()`
 
-## [1.0.0] - 2019-12-11
 
-### Changed
-
+## 1.0.0 - 2019-12-11
 * Use actix-net releases
 
 
-## [1.0.0-alpha.4] - 2019-12-08
-
-### Changed
-
+## 1.0.0-alpha.4 - 2019-12-08
 * Use actix-service 1.0.0-alpha.4
 
-## [1.0.0-alpha.3] - 2019-12-07
 
-### Changed
-
+## 1.0.0-alpha.3 - 2019-12-07
 * Migrate to tokio 0.2
-
-### Fixed
-
 * Fix compilation on non-unix platforms
-
 * Better handling server configuration
 
 
-## [1.0.0-alpha.2] - 2019-12-02
-
-### Changed
-
+## 1.0.0-alpha.2 - 2019-12-02
 * Simplify server service (remove actix-server-config)
-
 * Allow to wait on `Server` until server stops
 
 
-## [0.8.0-alpha.1] - 2019-11-22
-
-### Changed
-
+## 0.8.0-alpha.1 - 2019-11-22
 * Migrate to `std::future`
 
 
-## [0.7.0] - 2019-10-04
-
-### Changed
-
+## 0.7.0 - 2019-10-04
 * Update `rustls` to 0.16
 * Minimum required Rust version upped to 1.37.0
 
 
-## [0.6.1] - 2019-09-25
-
-### Added
-
+## 0.6.1 - 2019-09-25
 * Add UDS listening support to `ServerBuilder`
 
 
-## [0.6.0] - 2019-07-18
-
-### Added
-
+## 0.6.0 - 2019-07-18
 * Support Unix domain sockets #3
 
 
-## [0.5.1] - 2019-05-18
-
-### Changed
-
+## 0.5.1 - 2019-05-18
 * ServerBuilder::shutdown_timeout() accepts u64
 
 
-## [0.5.0] - 2019-05-12
-
-### Added
-
+## 0.5.0 - 2019-05-12
 * Add `Debug` impl for `SslError`
-
 * Derive debug for `Server` and `ServerCommand`
-
-### Changed
-
 * Upgrade to actix-service 0.4
 
 
-## [0.4.3] - 2019-04-16
-
-### Added
-
+## 0.4.3 - 2019-04-16
 * Re-export `IoStream` trait
-
-### Changed
-
-* Deppend on `ssl` and `rust-tls` features from actix-server-config
+* Depend on `ssl` and `rust-tls` features from actix-server-config
 
 
-## [0.4.2] - 2019-03-30
-
-### Fixed
-
+## 0.4.2 - 2019-03-30
 * Fix SIGINT force shutdown
 
 
-## [0.4.1] - 2019-03-14
-
-### Added
-
+## 0.4.1 - 2019-03-14
 * `SystemRuntime::on_start()` - allow to run future before server service initialization
 
 
-## [0.4.0] - 2019-03-12
-
-### Changed
-
+## 0.4.0 - 2019-03-12
 * Use `ServerConfig` for service factory
-
 * Wrap tcp socket to `Io` type
-
 * Upgrade actix-service
 
 
-## [0.3.1] - 2019-03-04
-
-### Added
-
+## 0.3.1 - 2019-03-04
 * Add `ServerBuilder::maxconnrate` sets the maximum per-worker number of concurrent connections
-
 * Add helper ssl error `SslError`
-
-
-### Changed
-
 * Rename `StreamServiceFactory` to `ServiceFactory`
-
 * Deprecate `StreamServiceFactory`
 
 
-## [0.3.0] - 2019-03-02
-
-### Changed
-
+## 0.3.0 - 2019-03-02
 * Use new `NewService` trait
 
 
-## [0.2.1] - 2019-02-09
-
-### Changed
-
+## 0.2.1 - 2019-02-09
 * Drop service response
 
 
-## [0.2.0] - 2019-02-01
-
-### Changed
-
+## 0.2.0 - 2019-02-01
 * Migrate to actix-service 0.2
-
 * Updated rustls dependency
 
 
-## [0.1.3] - 2018-12-21
-
-### Fixed
-
+## 0.1.3 - 2018-12-21
 * Fix max concurrent connections handling
 
 
-## [0.1.2] - 2018-12-12
-
-### Changed
-
+## 0.1.2 - 2018-12-12
 * rename ServiceConfig::rt() to ServiceConfig::apply()
-
-
-### Fixed
-
 * Fix back-pressure for concurrent ssl handshakes
 
 
-## [0.1.1] - 2018-12-11
-
+## 0.1.1 - 2018-12-11
 * Fix signal handling on windows
 
 
-## [0.1.0] - 2018-12-09
-
+## 0.1.0 - 2018-12-09
 * Move server to separate crate

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "actix-server"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
-description = "Actix server - General purpose tcp server"
+description = "General purpose TCP server built for the Actix ecosystem"
 keywords = ["network", "framework", "async", "futures"]
 homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-net.git"
@@ -11,7 +11,6 @@ categories = ["network-programming", "asynchronous"]
 license = "MIT OR Apache-2.0"
 exclude = [".gitignore", ".cargo/config"]
 edition = "2018"
-workspace = ".."
 
 [lib]
 name = "actix_server"
@@ -21,13 +20,13 @@ path = "src/lib.rs"
 default = []
 
 [dependencies]
-actix-service = "1.0.1"
-actix-rt = "1.0.0"
+actix-service = "1.0.6"
+actix-rt = "1.1.1"
 actix-codec = "0.3.0"
 actix-utils = "2.0.0"
 
 log = "0.4"
-num_cpus = "1.11"
+num_cpus = "1.13"
 mio = "0.6.19"
 socket2 = "0.3"
 futures-channel = { version = "0.3.4", default-features = false }

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -3,7 +3,7 @@ name = "actix-tls"
 version = "2.0.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "TLS acceptor services for Actix ecosystem."
-keywords = ["network", "framework", "async", "futures", "tls", "ssl"]
+keywords = ["network", "framework", "async", "tls", "ssl"]
 homepage = "https://actix.rs"
 repository = "https://github.com/actix/actix-net.git"
 documentation = "https://docs.rs/actix-tls/"
@@ -53,4 +53,4 @@ tokio-tls = { version = "0.3", optional = true }
 
 [dev-dependencies]
 bytes = "0.5"
-actix-testing = { version = "1.0.0" }
+actix-testing = "1.0.0"


### PR DESCRIPTION
## PR Type
Release


## PR Checklist
- [x] Tests for the changes have been run against actix-web.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
actix-server v1.0.3 uses actix-codec 0.2.0 so this patch release can remove that (unsafe) dependency.

While technically "breaking", I feel that the change ensuring that worker counts are greater than 0 is an acceptable one since a server is no good without at least 1 worker. As a quick check, I did a search of GitHub for `.workers(0)` in Rust files and came back with nothing. Thoughts from @actix/contributors are valuable here.