### PR TITLE
actix-service: Fix broken link in readme

### DIFF
--- a/actix-service/README.md
+++ b/actix-service/README.md
@@ -2,6 +2,6 @@
 
 > Service trait and combinators for representing asynchronous request/response operations.
 
-See documentation for detailed explanations these components: [https://docs.rs/actix-service](docs).
+See documentation for detailed explanations these components: [https://docs.rs/actix-service][docs].
 
 [docs]: https://docs.rs/actix-service


### PR DESCRIPTION
`(docs)` pointed to the non-existing `/docs` folder.