### PR TITLE
Add support of tokio-compat executor

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,6 +62,11 @@ jobs:
           command: test
           args: --all --all-features --no-fail-fast -- --nocapture
 
+      - name: tokio compat tests
+        run:
+          cd actix-rt
+          cargo test --features tokio-compat-executor --no-default-features
+
       - name: Generate coverage file
         if: matrix.version == 'stable' && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,7 +63,7 @@ jobs:
           args: --all --all-features --no-fail-fast -- --nocapture
 
       - name: tokio compat tests
-        run:
+        run: |
           cd actix-rt
           cargo test --features tokio-compat-executor --no-default-features
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,6 +43,6 @@ jobs:
           args: --all --all-features --no-fail-fast -- --nocapture
 
       - name: tokio compat tests
-        run:
+        run: |
           cd actix-rt
           cargo test --features tokio-compat-executor --no-default-features

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,3 +41,8 @@ jobs:
         with:
           command: test
           args: --all --all-features --no-fail-fast -- --nocapture
+
+      - name: tokio compat tests
+        run:
+          cd actix-rt
+          cargo test --features tokio-compat-executor --no-default-features

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,3 +67,8 @@ jobs:
         with:
           command: test
           args: --all --all-features --no-fail-fast -- --nocapture
+
+      - name: tokio compat tests
+        run:
+          cd actix-rt
+          cargo test --features tokio-compat-executor --no-default-features

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,6 +69,6 @@ jobs:
           args: --all --all-features --no-fail-fast -- --nocapture
 
       - name: tokio compat tests
-        run:
+        run: |
           cd actix-rt
           cargo test --features tokio-compat-executor --no-default-features

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -4,7 +4,11 @@
 
 ### Added
 
+* Add support of `tokio-compat` runtime. [#191]
 * Add `System::attach_to_tokio` method. [#173]
+
+[#173]: https://github.com/actix/actix-net/pull/173
+[#191]: https://github.com/actix/actix-net/pull/191
 
 ## [1.1.1] - 2020-04-30
 

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -22,7 +22,15 @@ futures-channel = { version = "0.3.4", default-features = false }
 futures-util = { version = "0.3.4", default-features = false, features = ["alloc"] }
 copyless = "0.1.4"
 smallvec = "1"
-tokio = { version = "0.2.6", default-features = false, features = ["rt-core", "rt-util", "io-driver", "tcp", "uds", "udp", "time", "signal", "stream"] }
+tokio = { version = "0.2.6", default-features = false, features = ["rt-core", "rt-util", "io-driver", "tcp", "uds", "udp", "time", "signal", "stream"], optional = true }
+tokio-compat = { version = "0.1.6", features = ["rt-full"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2.6", features = ["full"] }
+tokio01 = { package = "tokio", version = "0.1" }
+futures01 = { package = "futures", version = "0.1" }
+
+[features]
+default = ["tokio-executor"]
+tokio-executor = ["tokio"]
+tokio-compat-executor = ["tokio", "tokio-compat"]

--- a/actix-rt/src/builder.rs
+++ b/actix-rt/src/builder.rs
@@ -4,9 +4,9 @@ use std::io;
 use futures_channel::mpsc::unbounded;
 use futures_channel::oneshot::{channel, Receiver};
 use futures_util::future::{lazy, Future, FutureExt};
-use tokio::task::LocalSet;
 
 use crate::arbiter::{Arbiter, SystemArbiter};
+use crate::executor::LocalSet;
 use crate::runtime::Runtime;
 use crate::system::System;
 

--- a/actix-rt/src/executor.rs
+++ b/actix-rt/src/executor.rs
@@ -24,7 +24,7 @@ mod executor_impl {
 
     pub fn block_on_local<F>(rt: &mut Runtime, local: &LocalSet, f: F) -> F::Output
     where
-        F: std::future::Future + 'static,
+        F: std::future::Future,
     {
         local.block_on(rt, f)
     }
@@ -44,7 +44,7 @@ mod executor_impl {
 
     pub fn block_on_local<F>(rt: &mut Runtime, local: &LocalSet, f: F) -> F::Output
     where
-        F: std::future::Future + 'static,
+        F: std::future::Future,
     {
         rt.block_on_std(local.run_until(f))
     }

--- a/actix-rt/src/executor.rs
+++ b/actix-rt/src/executor.rs
@@ -1,4 +1,5 @@
 //! This module provides a wrapper abstraction around used executor.
+//! Depending on the provided feature, a corresponding set of types / helper functions is provided.
 //!
 //! Currently supported executors:
 //!

--- a/actix-rt/src/executor.rs
+++ b/actix-rt/src/executor.rs
@@ -1,0 +1,50 @@
+//! This module provides a wrapper abstraction around used executor.
+//!
+//! Currently supported executors:
+//!
+//! - `tokio` (default)
+//! - `tokio-compat`
+
+pub use self::executor_impl::*;
+
+#[cfg(feature = "tokio-executor")]
+mod executor_impl {
+    use std::io::Result;
+    pub use tokio::runtime::Runtime;
+    pub use tokio::task::{spawn_local, JoinHandle, LocalSet};
+
+    pub fn build_runtime() -> Result<Runtime> {
+        tokio::runtime::Builder::new()
+            .enable_io()
+            .enable_time()
+            .basic_scheduler()
+            .build()
+    }
+
+    pub fn block_on_local<F>(rt: &mut Runtime, local: &LocalSet, f: F) -> F::Output
+    where
+        F: std::future::Future + 'static,
+    {
+        local.block_on(rt, f)
+    }
+}
+
+#[cfg(all(not(feature = "tokio-executor"), feature = "tokio-compat-executor"))]
+mod executor_impl {
+    use std::io::Result;
+    pub use tokio::task::{spawn_local, JoinHandle, LocalSet};
+    pub use tokio_compat::runtime::Runtime;
+
+    pub fn build_runtime() -> Result<Runtime> {
+        tokio_compat::runtime::Builder::new()
+            .core_threads(1)
+            .build()
+    }
+
+    pub fn block_on_local<F>(rt: &mut Runtime, local: &LocalSet, f: F) -> F::Output
+    where
+        F: std::future::Future + 'static,
+    {
+        rt.block_on_std(local.run_until(f))
+    }
+}

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -7,6 +7,7 @@ pub use actix_macros::{main, test};
 
 mod arbiter;
 mod builder;
+mod executor;
 mod runtime;
 mod system;
 

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -186,7 +186,7 @@ impl System {
         rest_operations: Fut,
     ) -> R
     where
-        Fut: std::future::Future<Output = R> + 'static,
+        Fut: std::future::Future<Output = R>,
     {
         let actix_system_task = LocalSet::new();
         let sys = System::run_in_tokio(name.into(), &actix_system_task);


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

This PR adds experimental support of `tokio-compat` runtime.
In theory, it also provides a ground for making `actix-web` executor-agnostic, if that will ever be required.

For now, it makes `actix-rt` available for folks who have legacy code based on `tokio01`.

Resolves #163
