### PR TITLE
remove actix-threadpool re-export from actix-rt

### DIFF
--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -15,12 +15,16 @@ edition = "2018"
 name = "actix_rt"
 path = "src/lib.rs"
 
+[features]
+default = ["blocking"]
+blocking = ["actix-threadpool"]
+
 [dependencies]
 actix-macros = "0.1.0"
-actix-threadpool = "0.3"
-futures-channel = { version = "0.3.4", default-features = false }
-futures-util = { version = "0.3.4", default-features = false, features = ["alloc"] }
+actix-threadpool = { version = "0.3", optional = true }
 copyless = "0.1.4"
+futures-channel = "0.3.4"
+futures-util = { version = "0.3.4", default-features = false, features = ["alloc"] }
 smallvec = "1"
 tokio = { version = "0.2.6", default-features = false, features = ["rt-core", "rt-util", "io-driver", "tcp", "uds", "udp", "time", "signal", "stream"] }
 

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -15,13 +15,8 @@ edition = "2018"
 name = "actix_rt"
 path = "src/lib.rs"
 
-[features]
-default = ["blocking"]
-blocking = ["actix-threadpool"]
-
 [dependencies]
 actix-macros = "0.1.0"
-actix-threadpool = { version = "0.3", optional = true }
 copyless = "0.1.4"
 futures-channel = "0.3.4"
 futures-util = { version = "0.3.4", default-features = false, features = ["alloc"] }

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -134,10 +134,7 @@ impl Arbiter {
                     .unbounded_send(SystemCommand::RegisterArbiter(id, arb));
 
                 // run loop
-                let _ = match rt.block_on(stop_rx) {
-                    Ok(code) => code,
-                    Err(_) => 1,
-                };
+                let _ = rt.block_on(stop_rx).unwrap_or(1);
 
                 // unregister arbiter
                 let _ = System::current()

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -15,10 +15,6 @@ pub use self::builder::{Builder, SystemRunner};
 pub use self::runtime::Runtime;
 pub use self::system::System;
 
-#[doc(hidden)]
-#[cfg(feature = "blocking")]
-pub use actix_threadpool as blocking;
-
 /// Spawns a future on the current arbiter.
 ///
 /// # Panics

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -16,6 +16,7 @@ pub use self::runtime::Runtime;
 pub use self::system::System;
 
 #[doc(hidden)]
+#[cfg(feature = "blocking")]
 pub use actix_threadpool as blocking;
 
 /// Spawns a future on the current arbiter.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
By default `actix-rt` always re-export `actix-threadpool` and it's not alway used by the crates importing it.
This PR removes the dependecy.

As a result actix would have 3 less deps. 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
