### PR TITLE
Add a MapRequest middleware for preprocessing requests

### DIFF
--- a/actix-service/src/lib.rs
+++ b/actix-service/src/lib.rs
@@ -19,6 +19,7 @@ mod map;
 mod map_config;
 mod map_err;
 mod map_init_err;
+mod map_request;
 mod pipeline;
 mod then;
 mod transform;
@@ -28,6 +29,7 @@ pub use self::apply::{apply_fn, apply_fn_factory};
 pub use self::apply_cfg::{apply_cfg, apply_cfg_factory};
 pub use self::fn_service::{fn_factory, fn_factory_with_config, fn_service};
 pub use self::map_config::{map_config, unit_config};
+pub use self::map_request::{MapRequest, MapRequestMiddleware};
 pub use self::pipeline::{pipeline, pipeline_factory, Pipeline, PipelineFactory};
 pub use self::transform::{apply, Transform};
 

--- a/actix-service/src/map_request.rs
+++ b/actix-service/src/map_request.rs
@@ -1,0 +1,62 @@
+use std::{cell::RefCell, future::Future, rc::Rc};
+
+use futures_util::future::{self, FutureExt as _, LocalBoxFuture, TryFutureExt as _};
+
+use super::{Service, Transform};
+
+#[derive(Clone, Debug)]
+pub struct MapRequest<F>(pub F);
+
+pub struct MapRequestMiddleware<S, F> {
+    service: Rc<RefCell<S>>,
+    f: F,
+}
+
+impl<S, F, R> Transform<S> for MapRequest<F>
+where
+    S: Service + 'static,
+    F: FnMut(S::Request) -> R + Clone + 'static,
+    R: Future<Output = Result<S::Request, S::Error>> + 'static,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Transform = MapRequestMiddleware<S, F>;
+    type InitError = ();
+    type Future = future::Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        future::ok(MapRequestMiddleware {
+            service: Rc::new(RefCell::new(service)),
+            f: self.0.clone(),
+        })
+    }
+}
+
+impl<S, F, R> Service for MapRequestMiddleware<S, F>
+where
+    S: Service + 'static,
+    F: FnMut(S::Request) -> R + Clone + 'static,
+    R: Future<Output = Result<S::Request, S::Error>> + 'static,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = LocalBoxFuture<'static, Result<S::Response, S::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        ctx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.service.borrow_mut().poll_ready(ctx)
+    }
+
+    fn call(&mut self, req: Self::Request) -> Self::Future {
+        let mut f = self.f.clone();
+        let service = Rc::clone(&self.service);
+
+        f(req)
+            .and_then(move |req| service.borrow_mut().call(req))
+            .boxed_local()
+    }
+}


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

This is not much more than a dump of some code we have in our code base, but that would benefit from being included in actix-service. For actix-web users, it allows the equivalent of

```rust
.wrap_fn(|req, srv| async move {
    let req = my_preprocess_fn(req).await?;
    srv.call(req).await
})
```

or

```rust
.wrap_fn(|req, srv| my_preprocess_fn(req).and_then(|req| srv.call(req)))
```

(both don't work because of lifetime issues)

by just writing

```rust
.wrap(MapRequest(my_preprocess_fn))
```

which even if the first two snippets worked, is clearer and shorter, and thus desireable if done a lot.

I could write some docs and tests, but I'm not even 100% certain the implementation is correct (specifically `poll_ready`), and it isn't as efficient as it could be (the `LocalBoxFuture` shouldn't be necessary). Also whether this is the right naming wasn't clear when discussing the feature on Gitter previously.

I'd be really grateful if somebody could pick this up.

CC @robjtede who has been part of one or two discussions around this feature