### PR TITLE
Refactor LocalWaker

### DIFF
--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -333,7 +333,7 @@ impl Future for CleanupPending {
             let mut pending = cell.borrow_mut();
             let mut i = 0;
             while i != pending.len() {
-                if let Poll::Ready(_) = Pin::new(&mut pending[i]).poll(cx) {
+                if Pin::new(&mut pending[i]).poll(cx).is_ready() {
                     pending.remove(i);
                 } else {
                     i += 1;

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -286,7 +286,7 @@ impl ServerBuilder {
 
             // handle signals
             if !self.no_signals {
-                Signals::start(self.server.clone()).unwrap();
+                Signals::start(self.server.clone());
             }
 
             // start http server actor

--- a/actix-server/src/signals.rs
+++ b/actix-server/src/signals.rs
@@ -2,9 +2,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-#[cfg(not(unix))]
-use std::io;
-
 use futures_util::future::lazy;
 
 use crate::server::Server;
@@ -26,7 +23,7 @@ pub(crate) enum Signal {
 pub(crate) struct Signals {
     srv: Server,
     #[cfg(not(unix))]
-    stream: Pin<Box<dyn Future<Output = io::Result<()>>>>,
+    stream: Pin<Box<dyn Future<Output = std::io::Result<()>>>>,
     #[cfg(unix)]
     streams: Vec<(Signal, actix_rt::signal::unix::Signal)>,
 }

--- a/actix-server/src/signals.rs
+++ b/actix-server/src/signals.rs
@@ -1,7 +1,9 @@
 use std::future::Future;
-use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+#[cfg(not(unix))]
+use std::io;
 
 use futures_util::future::lazy;
 
@@ -30,7 +32,7 @@ pub(crate) struct Signals {
 }
 
 impl Signals {
-    pub(crate) fn start(srv: Server) -> io::Result<()> {
+    pub(crate) fn start(srv: Server) {
         actix_rt::spawn(lazy(|_| {
             #[cfg(not(unix))]
             {
@@ -66,8 +68,6 @@ impl Signals {
                 actix_rt::spawn(Signals { srv, streams })
             }
         }));
-
-        Ok(())
     }
 }
 

--- a/actix-utils/src/dispatcher.rs
+++ b/actix-utils/src/dispatcher.rs
@@ -290,10 +290,8 @@ where
                 }
                 State::Error(_) => {
                     // flush write buffer
-                    if !this.framed.is_write_buf_empty() {
-                        if let Poll::Pending = this.framed.flush(cx) {
-                            return Poll::Pending;
-                        }
+                    if !this.framed.is_write_buf_empty() && this.framed.flush(cx).is_pending() {
+                        return Poll::Pending;
                     }
                     Poll::Ready(Err(this.state.take_error()))
                 }

--- a/actix-utils/src/inflight.rs
+++ b/actix-utils/src/inflight.rs
@@ -74,7 +74,7 @@ where
     type Future = InFlightServiceResponse<T>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if let Poll::Pending = self.service.poll_ready(cx)? {
+        if self.service.poll_ready(cx)?.is_pending() {
             Poll::Pending
         } else if !self.count.available(cx) {
             log::trace!("InFlight limit exceeded");

--- a/actix-utils/src/order.rs
+++ b/actix-utils/src/order.rs
@@ -160,7 +160,12 @@ where
         }
 
         // check nested service
-        if let Poll::Pending = self.service.poll_ready(cx).map_err(InOrderError::Service)? {
+        if self
+            .service
+            .poll_ready(cx)
+            .map_err(InOrderError::Service)?
+            .is_pending()
+        {
             Poll::Pending
         } else {
             Poll::Ready(Ok(()))

--- a/actix-utils/src/task.rs
+++ b/actix-utils/src/task.rs
@@ -36,7 +36,7 @@ impl LocalWaker {
     }
 
     #[deprecated(
-        since = "2.x.x",
+        since = "2.1.0",
         note = "In favor of `wake`. State of the register doesn't matter at `wake` up"
     )]
     #[inline]

--- a/actix-utils/src/task.rs
+++ b/actix-utils/src/task.rs
@@ -19,6 +19,7 @@ use std::{fmt, rc};
 ///
 /// A single `AtomicWaker` may be reused for any number of calls to `register` or
 /// `wake`.
+// TODO: Refactor to Cell when remove deprecated methods (@botika)
 #[derive(Default)]
 pub struct LocalWaker {
     pub(crate) waker: UnsafeCell<Option<Waker>>,
@@ -34,6 +35,10 @@ impl LocalWaker {
         }
     }
 
+    #[deprecated(
+        since = "2.x.x",
+        note = "In favor of `wake`. State of the register doesn't matter at `wake` up"
+    )]
     #[inline]
     /// Check if waker has been registered.
     pub fn is_registered(&self) -> bool {
@@ -47,9 +52,8 @@ impl LocalWaker {
     pub fn register(&self, waker: &Waker) -> bool {
         unsafe {
             let w = self.waker.get();
-            let is_registered = (*w).is_some();
-            *w = Some(waker.clone());
-            is_registered
+            let last_waker = w.replace(Some(waker.clone()));
+            last_waker.is_some()
         }
     }
 
@@ -63,6 +67,7 @@ impl LocalWaker {
         }
     }
 
+    #[inline]
     /// Returns the last `Waker` passed to `register`, so that the user can wake it.
     ///
     /// If a waker has not been registered, this returns `None`.


### PR DESCRIPTION
~Simplify LocalWaker register method with `replace` mutable pointer method~

Refactor `LocalWaker`: `is_registered` has no real use because the only use of the registry is to wake up the task it refers to. But `wake` does not need the registration status, the behavior is the same whether a task is registered or not. So it has been removed in favor of `wake`. Without this method the use of `UnsafeCell` is not necessary so I have proposed a later refactor from `UnsafeCell` to `Cell`.