### PR TITLE
remove ServerMessage type. remove one unused InternalServiceFactory impl

### DIFF
--- a/actix-server/src/config.rs
+++ b/actix-server/src/config.rs
@@ -8,10 +8,9 @@ use futures_util::future::{ok, Future, FutureExt, LocalBoxFuture};
 use log::error;
 
 use super::builder::bind_addr;
-use super::service::{
-    BoxedServerService, InternalServiceFactory, ServerMessage, StreamService,
-};
+use super::service::{BoxedServerService, InternalServiceFactory, StreamService};
 use super::Token;
+use crate::socket::StdStream;
 
 pub struct ServiceConfig {
     pub(crate) services: Vec<(String, net::TcpListener)>,
@@ -239,7 +238,7 @@ impl ServiceRuntime {
 
 type BoxedNewService = Box<
     dyn actix::ServiceFactory<
-        Request = (Option<CounterGuard>, ServerMessage),
+        Request = (Option<CounterGuard>, StdStream),
         Response = (),
         Error = (),
         InitError = (),
@@ -261,12 +260,12 @@ where
     T::Error: 'static,
     T::InitError: fmt::Debug + 'static,
 {
-    type Request = (Option<CounterGuard>, ServerMessage);
+    type Request = (Option<CounterGuard>, StdStream);
     type Response = ();
     type Error = ();
-    type InitError = ();
     type Config = ();
     type Service = BoxedServerService;
+    type InitError = ();
     type Future = LocalBoxFuture<'static, Result<BoxedServerService, ()>>;
 
     fn new_service(&self, _: ()) -> Self::Future {


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`StreamService` is the only receiver of `ServerMessage` enum and only one variant is handled properly. This PR removes the enum
and pass `StdStream` directly to it.

`InternalServiceFactory` impl for `Box<dyn InternalServiceFactory>` is not necessary.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
