### PR TITLE
Intradoc links conversion

### DIFF
--- a/actix-codec/src/lib.rs
+++ b/actix-codec/src/lib.rs
@@ -4,8 +4,6 @@
 //! [`AsyncWrite`], to framed streams implementing [`Sink`] and [`Stream`].
 //! Framed streams are also known as `transports`.
 //!
-//! [`AsyncRead`]: AsyncRead
-//! [`AsyncWrite`]: AsyncWrite
 //! [`Sink`]: futures_sink::Sink
 //! [`Stream`]: futures_core::Stream
 

--- a/actix-connect/src/connect.rs
+++ b/actix-connect/src/connect.rs
@@ -138,7 +138,7 @@ impl<T: Address> fmt::Display for Connect<T> {
     }
 }
 
-/// Iterator over addresses in a [`Connect`](struct.Connect.html) request.
+/// Iterator over addresses in a [`Connect`] request.
 #[derive(Clone)]
 pub struct ConnectAddrsIter<'a> {
     inner: Either<Option<SocketAddr>, vec_deque::Iter<'a, SocketAddr>>,
@@ -173,7 +173,7 @@ impl ExactSizeIterator for ConnectAddrsIter<'_> {}
 
 impl FusedIterator for ConnectAddrsIter<'_> {}
 
-/// Owned iterator over addresses in a [`Connect`](struct.Connect.html) request.
+/// Owned iterator over addresses in a [`Connect`] request.
 #[derive(Debug)]
 pub struct ConnectTakeAddrsIter {
     inner: Either<Option<SocketAddr>, vec_deque::IntoIter<SocketAddr>>,

--- a/actix-rt/src/runtime.rs
+++ b/actix-rt/src/runtime.rs
@@ -7,7 +7,7 @@ use tokio::{runtime, task::LocalSet};
 ///
 /// See [module level][mod] documentation for more details.
 ///
-/// [mod]: index.html
+/// [mod]: crate
 #[derive(Debug)]
 pub struct Runtime {
     local: LocalSet,
@@ -34,7 +34,7 @@ impl Runtime {
     ///
     /// See [module level][mod] documentation for more details.
     ///
-    /// [mod]: index.html
+    /// [mod]: crate
     ///
     /// # Examples
     ///

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -66,7 +66,6 @@ impl System {
     /// It means that using this method currently it is impossible to make `actix-rt` work in the
     /// alternative `tokio` `Runtime`s (e.g. provided by [`tokio_compat`]).
     ///
-    /// [`Arbiter`]: struct.Arbiter.html
     /// [`tokio_compat`]: https://crates.io/crates/tokio-compat
     ///
     /// # Examples
@@ -131,7 +130,6 @@ impl System {
     /// It means that using this method currently it is impossible to make `actix-rt` work in the
     /// alternative `tokio` `Runtime`s (e.g. provided by `tokio_compat`).
     ///
-    /// [`Arbiter`]: struct.Arbiter.html
     /// [`tokio_compat`]: https://crates.io/crates/tokio-compat
     ///
     /// # Arguments

--- a/actix-service/src/lib.rs
+++ b/actix-service/src/lib.rs
@@ -1,4 +1,4 @@
-//! See [`Service`](trait.Service.html) docs for information on this crate's foundational trait.
+//! See [`Service`] docs for information on this crate's foundational trait.
 
 #![deny(rust_2018_idioms, nonstandard_style)]
 #![allow(clippy::type_complexity)]
@@ -67,7 +67,7 @@ pub use self::transform::{apply, Transform};
 /// ```
 ///
 /// Sometimes it is not necessary to implement the Service trait. For example, the above service
-/// could be rewritten as a simple function and passed to [fn_service](fn.fn_service.html).
+/// could be rewritten as a simple function and passed to [fn_service](fn_service()).
 ///
 /// ```rust,ignore
 /// async fn my_service(req: u8) -> Result<u64, MyError>;

--- a/actix-tracing/src/lib.rs
+++ b/actix-tracing/src/lib.rs
@@ -60,7 +60,6 @@ where
 }
 
 /// A `Transform` implementation that wraps services with a [`TracingService`].
-///
 pub struct TracingTransform<S, U, F> {
     make_span: F,
     _p: PhantomData<fn(S, U)>,

--- a/actix-tracing/src/lib.rs
+++ b/actix-tracing/src/lib.rs
@@ -61,7 +61,6 @@ where
 
 /// A `Transform` implementation that wraps services with a [`TracingService`].
 ///
-/// [`TracingService`]: struct.TracingService.html
 pub struct TracingTransform<S, U, F> {
     make_span: F,
     _p: PhantomData<fn(S, U)>,

--- a/string/src/lib.rs
+++ b/string/src/lib.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 
 /// A UTF-8 encoded string with [`Bytes`] as a storage.
 ///
-/// [`Bytes`]: https://docs.rs/bytes/0.5.3/bytes/struct.Bytes.html
+/// [`Bytes`]: bytes::Bytes
 #[derive(Clone, Eq, Ord, PartialOrd, Default)]
 pub struct ByteString(Bytes);
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Intradoc links


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
This PR migrates us to intradoc links. All documentation warnings were addressed and `cargo deadlinks` was run against the latest commit and all broken links were from `tokio`, `futures_util`, and `ppv_lite86`.
