### PR TITLE
Standardize bytes dependencies to version 0.5.6

### DIFF
--- a/actix-codec/Cargo.toml
+++ b/actix-codec/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.2.1"
-bytes = "0.5.2"
+bytes = "0.5.6"
 futures-core = { version = "0.3.4", default-features = false }
 futures-sink = { version = "0.3.4", default-features = false }
 log = "0.4"

--- a/actix-connect/Cargo.toml
+++ b/actix-connect/Cargo.toml
@@ -54,5 +54,5 @@ tokio-rustls = { version = "0.14.0", optional = true }
 webpki = { version = "0.21", optional = true }
 
 [dev-dependencies]
-bytes = "0.5.3"
+bytes = "0.5.6"
 actix-testing = "1.0.0"

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -38,7 +38,7 @@ slab = "0.4"
 mio-uds = { version = "0.6.7" }
 
 [dev-dependencies]
-bytes = "0.5"
+bytes = "0.5.6"
 env_logger = "0.7"
 actix-testing = "1.0.0"
 tokio = { version = "0.2", features = ["io-util"] }

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -56,7 +56,7 @@ native-tls = { version = "0.2", optional = true }
 tokio-tls = { version = "0.3", optional = true }
 
 [dev-dependencies]
-bytes = "0.5"
+bytes = "0.5.6"
 log = "0.4"
 env_logger = "0.7"
 actix-testing = "1.0.0"

--- a/actix-utils/Cargo.toml
+++ b/actix-utils/Cargo.toml
@@ -20,7 +20,7 @@ actix-codec = "0.3.0"
 actix-rt = "1.1.1"
 actix-service = "1.0.6"
 bitflags = "1.2.1"
-bytes = "0.5.3"
+bytes = "0.5.6"
 either = "1.5.3"
 futures-channel = { version = "0.3.4", default-features = false }
 futures-sink = { version = "0.3.4", default-features = false }

--- a/string/Cargo.toml
+++ b/string/Cargo.toml
@@ -15,7 +15,7 @@ name = "bytestring"
 path = "src/lib.rs"
 
 [dependencies]
-bytes = "0.5.3"
+bytes = "0.5.6"
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Use last compatible version of `bytes` with `tokio@0.2`