### PR TITLE
service trait takes request type parameter

### DIFF
--- a/actix-connect/src/connector.rs
+++ b/actix-connect/src/connector.rs
@@ -40,8 +40,7 @@ impl<T> Clone for TcpConnectorFactory<T> {
     }
 }
 
-impl<T: Address> ServiceFactory for TcpConnectorFactory<T> {
-    type Request = Connect<T>;
+impl<T: Address> ServiceFactory<Connect<T>> for TcpConnectorFactory<T> {
     type Response = Connection<T, TcpStream>;
     type Error = ConnectError;
     type Config = ();
@@ -70,8 +69,7 @@ impl<T> Clone for TcpConnector<T> {
     }
 }
 
-impl<T: Address> Service for TcpConnector<T> {
-    type Request = Connect<T>;
+impl<T: Address> Service<Connect<T>> for TcpConnector<T> {
     type Response = Connection<T, TcpStream>;
     type Error = ConnectError;
     #[allow(clippy::type_complexity)]

--- a/actix-connect/src/lib.rs
+++ b/actix-connect/src/lib.rs
@@ -76,8 +76,8 @@ pub async fn start_default_resolver() -> Result<AsyncResolver, ConnectError> {
 /// Create TCP connector service.
 pub fn new_connector<T: Address + 'static>(
     resolver: AsyncResolver,
-) -> impl Service<Request = Connect<T>, Response = Connection<T, TcpStream>, Error = ConnectError>
-       + Clone {
+) -> impl Service<Connect<T>, Response = Connection<T, TcpStream>, Error = ConnectError> + Clone
+{
     pipeline(Resolver::new(resolver)).and_then(TcpConnector::new())
 }
 
@@ -85,8 +85,8 @@ pub fn new_connector<T: Address + 'static>(
 pub fn new_connector_factory<T: Address + 'static>(
     resolver: AsyncResolver,
 ) -> impl ServiceFactory<
+    Connect<T>,
     Config = (),
-    Request = Connect<T>,
     Response = Connection<T, TcpStream>,
     Error = ConnectError,
     InitError = (),
@@ -96,15 +96,15 @@ pub fn new_connector_factory<T: Address + 'static>(
 
 /// Create connector service with default parameters.
 pub fn default_connector<T: Address + 'static>(
-) -> impl Service<Request = Connect<T>, Response = Connection<T, TcpStream>, Error = ConnectError>
-       + Clone {
+) -> impl Service<Connect<T>, Response = Connection<T, TcpStream>, Error = ConnectError> + Clone
+{
     pipeline(Resolver::default()).and_then(TcpConnector::new())
 }
 
 /// Create connector service factory with default parameters.
 pub fn default_connector_factory<T: Address + 'static>() -> impl ServiceFactory<
+    Connect<T>,
     Config = (),
-    Request = Connect<T>,
     Response = Connection<T, TcpStream>,
     Error = ConnectError,
     InitError = (),

--- a/actix-connect/src/resolve.rs
+++ b/actix-connect/src/resolve.rs
@@ -54,8 +54,7 @@ impl<T> Clone for ResolverFactory<T> {
     }
 }
 
-impl<T: Address> ServiceFactory for ResolverFactory<T> {
-    type Request = Connect<T>;
+impl<T: Address> ServiceFactory<Connect<T>> for ResolverFactory<T> {
     type Response = Connect<T>;
     type Error = ConnectError;
     type Config = ();
@@ -102,8 +101,7 @@ impl<T> Clone for Resolver<T> {
     }
 }
 
-impl<T: Address> Service for Resolver<T> {
-    type Request = Connect<T>;
+impl<T: Address> Service<Connect<T>> for Resolver<T> {
     type Response = Connect<T>;
     type Error = ConnectError;
     #[allow(clippy::type_complexity)]

--- a/actix-connect/src/service.rs
+++ b/actix-connect/src/service.rs
@@ -70,8 +70,7 @@ impl<T> Clone for ConnectServiceFactory<T> {
     }
 }
 
-impl<T: Address> ServiceFactory for ConnectServiceFactory<T> {
-    type Request = Connect<T>;
+impl<T: Address> ServiceFactory<Connect<T>> for ConnectServiceFactory<T> {
     type Response = Connection<T, TcpStream>;
     type Error = ConnectError;
     type Config = ();
@@ -90,8 +89,7 @@ pub struct ConnectService<T> {
     resolver: Resolver<T>,
 }
 
-impl<T: Address> Service for ConnectService<T> {
-    type Request = Connect<T>;
+impl<T: Address> Service<Connect<T>> for ConnectService<T> {
     type Response = Connection<T, TcpStream>;
     type Error = ConnectError;
     type Future = ConnectServiceResponse<T>;
@@ -109,8 +107,8 @@ impl<T: Address> Service for ConnectService<T> {
 }
 
 enum ConnectState<T: Address> {
-    Resolve(<Resolver<T> as Service>::Future),
-    Connect(<TcpConnector<T> as Service>::Future),
+    Resolve(<Resolver<T> as Service<Connect<T>>>::Future),
+    Connect(<TcpConnector<T> as Service<Connect<T>>>::Future),
 }
 
 impl<T: Address> ConnectState<T> {
@@ -160,8 +158,7 @@ pub struct TcpConnectService<T> {
     resolver: Resolver<T>,
 }
 
-impl<T: Address + 'static> Service for TcpConnectService<T> {
-    type Request = Connect<T>;
+impl<T: Address + 'static> Service<Connect<T>> for TcpConnectService<T> {
     type Response = TcpStream;
     type Error = ConnectError;
     type Future = TcpConnectServiceResponse<T>;
@@ -179,8 +176,8 @@ impl<T: Address + 'static> Service for TcpConnectService<T> {
 }
 
 enum TcpConnectState<T: Address> {
-    Resolve(<Resolver<T> as Service>::Future),
-    Connect(<TcpConnector<T> as Service>::Future),
+    Resolve(<Resolver<T> as Service<Connect<T>>>::Future),
+    Connect(<TcpConnector<T> as Service<Connect<T>>>::Future),
 }
 
 impl<T: Address> TcpConnectState<T> {

--- a/actix-server/src/service.rs
+++ b/actix-server/src/service.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::task::{Context, Poll};
 
 use actix_rt::spawn;
-use actix_service::{self as actix, Service, ServiceFactory as ActixServiceFactory};
+use actix_service::{Service, ServiceFactory as BaseServiceFactory};
 use actix_utils::counter::CounterGuard;
 use futures_util::future::{err, ok, LocalBoxFuture, Ready};
 use futures_util::{FutureExt, TryFutureExt};
@@ -13,7 +13,7 @@ use super::Token;
 use crate::socket::{FromStream, StdStream};
 
 pub trait ServiceFactory<Stream: FromStream>: Send + Clone + 'static {
-    type Factory: actix::ServiceFactory<Config = (), Request = Stream>;
+    type Factory: BaseServiceFactory<Stream, Config = ()>;
 
     fn create(&self) -> Self::Factory;
 }
@@ -28,31 +28,34 @@ pub(crate) trait InternalServiceFactory: Send {
 
 pub(crate) type BoxedServerService = Box<
     dyn Service<
-        Request = (Option<CounterGuard>, StdStream),
+        (Option<CounterGuard>, StdStream),
         Response = (),
         Error = (),
         Future = Ready<Result<(), ()>>,
     >,
 >;
 
-pub(crate) struct StreamService<T> {
-    service: T,
+pub(crate) struct StreamService<S, I> {
+    service: S,
+    _phantom: PhantomData<I>,
 }
 
-impl<T> StreamService<T> {
-    pub(crate) fn new(service: T) -> Self {
-        StreamService { service }
+impl<S, I> StreamService<S, I> {
+    pub(crate) fn new(service: S) -> Self {
+        StreamService {
+            service,
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<T, I> Service for StreamService<T>
+impl<S, I> Service<(Option<CounterGuard>, StdStream)> for StreamService<S, I>
 where
-    T: Service<Request = I>,
-    T::Future: 'static,
-    T::Error: 'static,
+    S: Service<I>,
+    S::Future: 'static,
+    S::Error: 'static,
     I: FromStream,
 {
-    type Request = (Option<CounterGuard>, StdStream);
     type Response = ();
     type Error = ();
     type Future = Ready<Result<(), ()>>;
@@ -144,7 +147,7 @@ where
 impl<F, T, I> ServiceFactory<I> for F
 where
     F: Fn() -> T + Send + Clone + 'static,
-    T: actix::ServiceFactory<Config = (), Request = I>,
+    T: BaseServiceFactory<I, Config = ()>,
     I: FromStream,
 {
     type Factory = T;

--- a/actix-service/CHANGES.md
+++ b/actix-service/CHANGES.md
@@ -1,7 +1,13 @@
 # Changes
 
 ## Unreleased - 2020-xx-xx
+* `Service`, other traits, and many type signatures now take the the request type as a type
+  parameter instead of an associated type. [#232]
 * Upgrade `pin-project` to `1.0`.
+
+
+[#232]: https://github.com/actix/actix-net/pull/232
+
 
 ## 1.0.6 - 2020-08-09
 

--- a/actix-service/benches/and_then.rs
+++ b/actix-service/benches/and_then.rs
@@ -5,11 +5,14 @@ use actix_service::Service;
 use criterion::{criterion_main, Criterion};
 use futures_util::future::join_all;
 use futures_util::future::TryFutureExt;
-use std::cell::{RefCell, UnsafeCell};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
+use std::{
+    cell::{RefCell, UnsafeCell},
+    marker::PhantomData,
+};
 
 /*
  * Test services A,B for AndThen service implementations
@@ -28,71 +31,72 @@ async fn svc2(req: usize) -> Result<usize, ()> {
  * Cut down version of actix_service::AndThenService based on actix-service::Cell
  */
 
-struct AndThenUC<A, B>(Rc<UnsafeCell<(A, B)>>);
+struct AndThenUC<A, Req, B>(Rc<UnsafeCell<(A, B)>>, PhantomData<Req>);
 
-impl<A, B> AndThenUC<A, B> {
+impl<A, Req, B> AndThenUC<A, Req, B> {
     fn new(a: A, b: B) -> Self
     where
-        A: Service,
-        B: Service<Request = A::Response, Error = A::Error>,
+        A: Service<Req>,
+        B: Service<A::Response, Error = A::Error>,
     {
-        Self(Rc::new(UnsafeCell::new((a, b))))
+        Self(Rc::new(UnsafeCell::new((a, b))), PhantomData)
     }
 }
 
-impl<A, B> Clone for AndThenUC<A, B> {
+impl<A, Req, B> Clone for AndThenUC<A, Req, B> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self(self.0.clone(), PhantomData)
     }
 }
 
-impl<A, B> Service for AndThenUC<A, B>
+impl<A, Req, B> Service<Req> for AndThenUC<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
-    type Request = A::Request;
     type Response = B::Response;
     type Error = A::Error;
-    type Future = AndThenServiceResponse<A, B>;
+    type Future = AndThenServiceResponse<A, Req, B>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: A::Request) -> Self::Future {
+    fn call(&mut self, req: Req) -> Self::Future {
         let fut = unsafe { &mut *(*self.0).get() }.0.call(req);
         AndThenServiceResponse {
             state: State::A(fut, Some(self.0.clone())),
+            _phantom: PhantomData,
         }
     }
 }
 
 #[pin_project::pin_project]
-pub(crate) struct AndThenServiceResponse<A, B>
+pub(crate) struct AndThenServiceResponse<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     #[pin]
-    state: State<A, B>,
+    state: State<A, Req, B>,
+    _phantom: PhantomData<Req>,
 }
 
 #[pin_project::pin_project(project = StateProj)]
-enum State<A, B>
+enum State<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     A(#[pin] A::Future, Option<Rc<UnsafeCell<(A, B)>>>),
     B(#[pin] B::Future),
-    Empty,
+    Empty(PhantomData<Req>),
 }
 
-impl<A, B> Future for AndThenServiceResponse<A, B>
+impl<A, Req, B> Future for AndThenServiceResponse<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     type Output = Result<B::Response, A::Error>;
 
@@ -103,7 +107,7 @@ where
             StateProj::A(fut, b) => match fut.poll(cx)? {
                 Poll::Ready(res) => {
                     let b = b.take().unwrap();
-                    this.state.set(State::Empty); // drop fut A
+                    this.state.set(State::Empty(PhantomData)); // drop fut A
                     let fut = unsafe { &mut (*b.get()).1 }.call(res);
                     this.state.set(State::B(fut));
                     self.poll(cx)
@@ -111,10 +115,10 @@ where
                 Poll::Pending => Poll::Pending,
             },
             StateProj::B(fut) => fut.poll(cx).map(|r| {
-                this.state.set(State::Empty);
+                this.state.set(State::Empty(PhantomData));
                 r
             }),
-            StateProj::Empty => {
+            StateProj::Empty(_) => {
                 panic!("future must not be polled after it returned `Poll::Ready`")
             }
         }
@@ -125,39 +129,38 @@ where
  * AndThenRC - AndThen service based on RefCell
  */
 
-struct AndThenRC<A, B>(Rc<RefCell<(A, B)>>);
+struct AndThenRC<A, Req, B>(Rc<RefCell<(A, B)>>, PhantomData<Req>);
 
-impl<A, B> AndThenRC<A, B> {
+impl<A, Req, B> AndThenRC<A, Req, B> {
     fn new(a: A, b: B) -> Self
     where
-        A: Service,
-        B: Service<Request = A::Response, Error = A::Error>,
+        A: Service<Req>,
+        B: Service<A::Response, Error = A::Error>,
     {
-        Self(Rc::new(RefCell::new((a, b))))
+        Self(Rc::new(RefCell::new((a, b))), PhantomData)
     }
 }
 
-impl<A, B> Clone for AndThenRC<A, B> {
+impl<A, Req, B> Clone for AndThenRC<A, Req, B> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self(self.0.clone(), PhantomData)
     }
 }
 
-impl<A, B> Service for AndThenRC<A, B>
+impl<A, Req, B> Service<Req> for AndThenRC<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
-    type Request = A::Request;
     type Response = B::Response;
     type Error = A::Error;
-    type Future = AndThenServiceResponseRC<A, B>;
+    type Future = AndThenServiceResponseRC<A, Req, B>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: A::Request) -> Self::Future {
+    fn call(&mut self, req: Req) -> Self::Future {
         let fut = self.0.borrow_mut().0.call(req);
         AndThenServiceResponseRC {
             state: StateRC::A(fut, Some(self.0.clone())),
@@ -166,30 +169,30 @@ where
 }
 
 #[pin_project::pin_project]
-pub(crate) struct AndThenServiceResponseRC<A, B>
+pub(crate) struct AndThenServiceResponseRC<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     #[pin]
-    state: StateRC<A, B>,
+    state: StateRC<A, Req, B>,
 }
 
 #[pin_project::pin_project(project = StateRCProj)]
-enum StateRC<A, B>
+enum StateRC<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     A(#[pin] A::Future, Option<Rc<RefCell<(A, B)>>>),
     B(#[pin] B::Future),
-    Empty,
+    Empty(PhantomData<Req>),
 }
 
-impl<A, B> Future for AndThenServiceResponseRC<A, B>
+impl<A, Req, B> Future for AndThenServiceResponseRC<A, Req, B>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     type Output = Result<B::Response, A::Error>;
 
@@ -200,7 +203,7 @@ where
             StateRCProj::A(fut, b) => match fut.poll(cx)? {
                 Poll::Ready(res) => {
                     let b = b.take().unwrap();
-                    this.state.set(StateRC::Empty); // drop fut A
+                    this.state.set(StateRC::Empty(PhantomData)); // drop fut A
                     let fut = b.borrow_mut().1.call(res);
                     this.state.set(StateRC::B(fut));
                     self.poll(cx)
@@ -208,10 +211,10 @@ where
                 Poll::Pending => Poll::Pending,
             },
             StateRCProj::B(fut) => fut.poll(cx).map(|r| {
-                this.state.set(StateRC::Empty);
+                this.state.set(StateRC::Empty(PhantomData));
                 r
             }),
-            StateRCProj::Empty => {
+            StateRCProj::Empty(_) => {
                 panic!("future must not be polled after it returned `Poll::Ready`")
             }
         }
@@ -223,32 +226,31 @@ where
  * and standard futures::future::and_then combinator in a Box
  */
 
-struct AndThenRCFuture<A, B>(Rc<RefCell<(A, B)>>);
+struct AndThenRCFuture<A, Req, B>(Rc<RefCell<(A, B)>>, PhantomData<Req>);
 
-impl<A, B> AndThenRCFuture<A, B> {
+impl<A, Req, B> AndThenRCFuture<A, Req, B> {
     fn new(a: A, b: B) -> Self
     where
-        A: Service,
-        B: Service<Request = A::Response, Error = A::Error>,
+        A: Service<Req>,
+        B: Service<A::Response, Error = A::Error>,
     {
-        Self(Rc::new(RefCell::new((a, b))))
+        Self(Rc::new(RefCell::new((a, b))), PhantomData)
     }
 }
 
-impl<A, B> Clone for AndThenRCFuture<A, B> {
+impl<A, Req, B> Clone for AndThenRCFuture<A, Req, B> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self(self.0.clone(), PhantomData)
     }
 }
 
-impl<A, B> Service for AndThenRCFuture<A, B>
+impl<A, Req, B> Service<Req> for AndThenRCFuture<A, Req, B>
 where
-    A: Service + 'static,
+    A: Service<Req> + 'static,
     A::Future: 'static,
-    B: Service<Request = A::Response, Error = A::Error> + 'static,
+    B: Service<A::Response, Error = A::Error> + 'static,
     B::Future: 'static,
 {
-    type Request = A::Request;
     type Response = B::Response;
     type Error = A::Error;
     type Future = BoxFuture<Self::Response, Self::Error>;
@@ -257,7 +259,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: A::Request) -> Self::Future {
+    fn call(&mut self, req: Req) -> Self::Future {
         let fut = self.0.borrow_mut().0.call(req);
         let core = self.0.clone();
         let fut2 = move |res| (*core).borrow_mut().1.call(res);
@@ -281,7 +283,7 @@ where
 /// async_service_direct    time:   [1.0908 us 1.1656 us 1.2613 us]
 pub fn bench_async_service<S>(c: &mut Criterion, srv: S, name: &str)
 where
-    S: Service<Request = (), Response = usize, Error = ()> + Clone + 'static,
+    S: Service<(), Response = usize, Error = ()> + Clone + 'static,
 {
     let mut rt = actix_rt::System::new("test");
 

--- a/actix-service/benches/unsafecell_vs_refcell.rs
+++ b/actix-service/benches/unsafecell_vs_refcell.rs
@@ -20,8 +20,7 @@ impl Clone for SrvUC {
     }
 }
 
-impl Service for SrvUC {
-    type Request = ();
+impl Service<()> for SrvUC {
     type Response = usize;
     type Error = ();
     type Future = Ready<Result<Self::Response, ()>>;
@@ -50,8 +49,7 @@ impl Clone for SrvRC {
     }
 }
 
-impl Service for SrvRC {
-    type Request = ();
+impl Service<()> for SrvRC {
     type Response = usize;
     type Error = ();
     type Future = Ready<Result<Self::Response, ()>>;
@@ -83,7 +81,7 @@ impl Service for SrvRC {
 /// async_service_direct    time:   [1.0908 us 1.1656 us 1.2613 us]
 pub fn bench_async_service<S>(c: &mut Criterion, srv: S, name: &str)
 where
-    S: Service<Request = (), Response = usize, Error = ()> + Clone + 'static,
+    S: Service<(), Response = usize, Error = ()> + Clone + 'static,
 {
     let mut rt = actix_rt::System::new("test");
 

--- a/actix-service/src/and_then.rs
+++ b/actix-service/src/and_then.rs
@@ -121,6 +121,7 @@ where
     >,
 {
     inner: Rc<(A, B)>,
+    _phantom: PhantomData<Req>,
 }
 
 impl<A, B, Req> AndThenServiceFactory<A, B, Req>
@@ -138,6 +139,7 @@ where
     pub(crate) fn new(a: A, b: B) -> Self {
         Self {
             inner: Rc::new((a, b)),
+            _phantom: PhantomData,
         }
     }
 }
@@ -184,6 +186,7 @@ where
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/actix-service/src/and_then.rs
+++ b/actix-service/src/and_then.rs
@@ -1,8 +1,8 @@
-use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
+use std::{cell::RefCell, marker::PhantomData};
 
 use super::{Service, ServiceFactory};
 
@@ -10,34 +10,33 @@ use super::{Service, ServiceFactory};
 /// of another service which completes successfully.
 ///
 /// This is created by the `Pipeline::and_then` method.
-pub(crate) struct AndThenService<A, B>(Rc<RefCell<(A, B)>>);
+pub(crate) struct AndThenService<A, B, Req>(Rc<RefCell<(A, B)>>, PhantomData<Req>);
 
-impl<A, B> AndThenService<A, B> {
+impl<A, B, Req> AndThenService<A, B, Req> {
     /// Create new `AndThen` combinator
     pub(crate) fn new(a: A, b: B) -> Self
     where
-        A: Service,
-        B: Service<Request = A::Response, Error = A::Error>,
+        A: Service<Req>,
+        B: Service<A::Response, Error = A::Error>,
     {
-        Self(Rc::new(RefCell::new((a, b))))
+        Self(Rc::new(RefCell::new((a, b))), PhantomData)
     }
 }
 
-impl<A, B> Clone for AndThenService<A, B> {
+impl<A, B, Req> Clone for AndThenService<A, B, Req> {
     fn clone(&self) -> Self {
-        AndThenService(self.0.clone())
+        AndThenService(self.0.clone(), PhantomData)
     }
 }
 
-impl<A, B> Service for AndThenService<A, B>
+impl<A, B, Req> Service<Req> for AndThenService<A, B, Req>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
-    type Request = A::Request;
     type Response = B::Response;
     type Error = A::Error;
-    type Future = AndThenServiceResponse<A, B>;
+    type Future = AndThenServiceResponse<A, B, Req>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let mut srv = self.0.borrow_mut();
@@ -49,7 +48,7 @@ where
         }
     }
 
-    fn call(&mut self, req: A::Request) -> Self::Future {
+    fn call(&mut self, req: Req) -> Self::Future {
         AndThenServiceResponse {
             state: State::A(self.0.borrow_mut().0.call(req), Some(self.0.clone())),
         }
@@ -57,30 +56,30 @@ where
 }
 
 #[pin_project::pin_project]
-pub(crate) struct AndThenServiceResponse<A, B>
+pub(crate) struct AndThenServiceResponse<A, B, Req>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     #[pin]
-    state: State<A, B>,
+    state: State<A, B, Req>,
 }
 
 #[pin_project::pin_project(project = StateProj)]
-enum State<A, B>
+enum State<A, B, Req>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     A(#[pin] A::Future, Option<Rc<RefCell<(A, B)>>>),
     B(#[pin] B::Future),
     Empty,
 }
 
-impl<A, B> Future for AndThenServiceResponse<A, B>
+impl<A, B, Req> Future for AndThenServiceResponse<A, B, Req>
 where
-    A: Service,
-    B: Service<Request = A::Response, Error = A::Error>,
+    A: Service<Req>,
+    B: Service<A::Response, Error = A::Error>,
 {
     type Output = Result<B::Response, A::Error>;
 
@@ -110,13 +109,13 @@ where
 }
 
 /// `.and_then()` service factory combinator
-pub(crate) struct AndThenServiceFactory<A, B>
+pub(crate) struct AndThenServiceFactory<A, B, Req>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     A::Config: Clone,
     B: ServiceFactory<
+        A::Response,
         Config = A::Config,
-        Request = A::Response,
         Error = A::Error,
         InitError = A::InitError,
     >,
@@ -124,13 +123,13 @@ where
     inner: Rc<(A, B)>,
 }
 
-impl<A, B> AndThenServiceFactory<A, B>
+impl<A, B, Req> AndThenServiceFactory<A, B, Req>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     A::Config: Clone,
     B: ServiceFactory<
+        A::Response,
         Config = A::Config,
-        Request = A::Response,
         Error = A::Error,
         InitError = A::InitError,
     >,
@@ -143,25 +142,24 @@ where
     }
 }
 
-impl<A, B> ServiceFactory for AndThenServiceFactory<A, B>
+impl<A, B, Req> ServiceFactory<Req> for AndThenServiceFactory<A, B, Req>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     A::Config: Clone,
     B: ServiceFactory<
+        A::Response,
         Config = A::Config,
-        Request = A::Response,
         Error = A::Error,
         InitError = A::InitError,
     >,
 {
-    type Request = A::Request;
     type Response = B::Response;
     type Error = A::Error;
 
     type Config = A::Config;
-    type Service = AndThenService<A::Service, B::Service>;
+    type Service = AndThenService<A::Service, B::Service, Req>;
     type InitError = A::InitError;
-    type Future = AndThenServiceFactoryResponse<A, B>;
+    type Future = AndThenServiceFactoryResponse<A, B, Req>;
 
     fn new_service(&self, cfg: A::Config) -> Self::Future {
         let inner = &*self.inner;
@@ -172,13 +170,13 @@ where
     }
 }
 
-impl<A, B> Clone for AndThenServiceFactory<A, B>
+impl<A, B, Req> Clone for AndThenServiceFactory<A, B, Req>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     A::Config: Clone,
     B: ServiceFactory<
+        A::Response,
         Config = A::Config,
-        Request = A::Response,
         Error = A::Error,
         InitError = A::InitError,
     >,
@@ -191,10 +189,10 @@ where
 }
 
 #[pin_project::pin_project]
-pub(crate) struct AndThenServiceFactoryResponse<A, B>
+pub(crate) struct AndThenServiceFactoryResponse<A, B, Req>
 where
-    A: ServiceFactory,
-    B: ServiceFactory<Request = A::Response>,
+    A: ServiceFactory<Req>,
+    B: ServiceFactory<A::Response>,
 {
     #[pin]
     fut_a: A::Future,
@@ -205,10 +203,10 @@ where
     b: Option<B::Service>,
 }
 
-impl<A, B> AndThenServiceFactoryResponse<A, B>
+impl<A, B, Req> AndThenServiceFactoryResponse<A, B, Req>
 where
-    A: ServiceFactory,
-    B: ServiceFactory<Request = A::Response>,
+    A: ServiceFactory<Req>,
+    B: ServiceFactory<A::Response>,
 {
     fn new(fut_a: A::Future, fut_b: B::Future) -> Self {
         AndThenServiceFactoryResponse {
@@ -220,12 +218,12 @@ where
     }
 }
 
-impl<A, B> Future for AndThenServiceFactoryResponse<A, B>
+impl<A, B, Req> Future for AndThenServiceFactoryResponse<A, B, Req>
 where
-    A: ServiceFactory,
-    B: ServiceFactory<Request = A::Response, Error = A::Error, InitError = A::InitError>,
+    A: ServiceFactory<Req>,
+    B: ServiceFactory<A::Response, Error = A::Error, InitError = A::InitError>,
 {
-    type Output = Result<AndThenService<A::Service, B::Service>, A::InitError>;
+    type Output = Result<AndThenService<A::Service, B::Service, Req>, A::InitError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -263,8 +261,7 @@ mod tests {
 
     struct Srv1(Rc<Cell<usize>>);
 
-    impl Service for Srv1 {
-        type Request = &'static str;
+    impl Service<&'static str> for Srv1 {
         type Response = &'static str;
         type Error = ();
         type Future = Ready<Result<Self::Response, ()>>;
@@ -282,8 +279,7 @@ mod tests {
     #[derive(Clone)]
     struct Srv2(Rc<Cell<usize>>);
 
-    impl Service for Srv2 {
-        type Request = &'static str;
+    impl Service<&'static str> for Srv2 {
         type Response = (&'static str, &'static str);
         type Error = ();
         type Future = Ready<Result<Self::Response, ()>>;

--- a/actix-service/src/and_then_apply_fn.rs
+++ b/actix-service/src/and_then_apply_fn.rs
@@ -8,65 +8,67 @@ use std::task::{Context, Poll};
 use crate::{Service, ServiceFactory};
 
 /// `Apply` service combinator
-pub(crate) struct AndThenApplyFn<A, B, F, Fut, Req, Res, Err>
+pub(crate) struct AndThenApplyFn<S1, S2, F, Fut, Req, In, Res, Err>
 where
-    A: Service<Req>,
-    B: Service<Result<A::Response, A::Error>>,
-    F: FnMut(A::Response, &mut B) -> Fut,
+    S1: Service<Req>,
+    S2: Service<In>,
+    F: FnMut(S1::Response, &mut S2) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<S1::Error> + From<S2::Error>,
 {
-    srv: Rc<RefCell<(A, B, F)>>,
-    r: PhantomData<(Fut, Res, Err)>,
+    svc: Rc<RefCell<(S1, S2, F)>>,
+    _phantom: PhantomData<(Fut, Req, In, Res, Err)>,
 }
 
-impl<A, B, F, Fut, Req, Res, Err> AndThenApplyFn<A, B, F, Fut, Req, Res, Err>
+impl<S1, S2, F, Fut, Req, In, Res, Err> AndThenApplyFn<S1, S2, F, Fut, Req, In, Res, Err>
 where
-    A: Service<Req>,
-    B: Service<Result<A::Response, A::Error>>,
-    F: FnMut(A::Response, &mut B) -> Fut,
+    S1: Service<Req>,
+    S2: Service<In>,
+    F: FnMut(S1::Response, &mut S2) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<S1::Error> + From<S2::Error>,
 {
     /// Create new `Apply` combinator
-    pub(crate) fn new(a: A, b: B, f: F) -> Self {
+    pub(crate) fn new(a: S1, b: S2, wrap_fn: F) -> Self {
         Self {
-            srv: Rc::new(RefCell::new((a, b, f))),
-            r: PhantomData,
+            svc: Rc::new(RefCell::new((a, b, wrap_fn))),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<A, B, F, Fut, Req, Res, Err> Clone for AndThenApplyFn<A, B, F, Fut, Req, Res, Err>
+impl<S1, S2, F, Fut, Req, In, Res, Err> Clone
+    for AndThenApplyFn<S1, S2, F, Fut, Req, In, Res, Err>
 where
-    A: Service<Req>,
-    B: Service<Result<A::Response, A::Error>>,
-    F: FnMut(A::Response, &mut B) -> Fut,
+    S1: Service<Req>,
+    S2: Service<In>,
+    F: FnMut(S1::Response, &mut S2) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<S1::Error> + From<S2::Error>,
 {
     fn clone(&self) -> Self {
         AndThenApplyFn {
-            srv: self.srv.clone(),
-            r: PhantomData,
+            svc: self.svc.clone(),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<A, B, F, Fut, Req, Res, Err> Service<Req> for AndThenApplyFn<A, B, F, Fut, Req, Res, Err>
+impl<S1, S2, F, Fut, Req, In, Res, Err> Service<Req>
+    for AndThenApplyFn<S1, S2, F, Fut, Req, In, Res, Err>
 where
-    A: Service<Req>,
-    B: Service<Result<A::Response, A::Error>>,
-    F: FnMut(A::Response, &mut B) -> Fut,
+    S1: Service<Req>,
+    S2: Service<In>,
+    F: FnMut(S1::Response, &mut S2) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<S1::Error> + From<S2::Error>,
 {
     type Response = Res;
     type Error = Err;
-    type Future = AndThenApplyFnFuture<A, B, F, Fut, Req, Res, Err>;
+    type Future = AndThenApplyFnFuture<S1, S2, F, Fut, Req, In, Res, Err>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let mut inner = self.srv.borrow_mut();
+        let mut inner = self.svc.borrow_mut();
         let not_ready = inner.0.poll_ready(cx)?.is_pending();
         if inner.1.poll_ready(cx)?.is_pending() || not_ready {
             Poll::Pending
@@ -76,49 +78,48 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let fut = self.srv.borrow_mut().0.call(req);
+        let fut = self.svc.borrow_mut().0.call(req);
         AndThenApplyFnFuture {
-            state: State::A(fut, Some(self.srv.clone())),
+            state: State::A(fut, Some(self.svc.clone())),
         }
     }
 }
 
 #[pin_project::pin_project]
-pub(crate) struct AndThenApplyFnFuture<A, B, F, Fut, Req, Res, Err>
+pub(crate) struct AndThenApplyFnFuture<S1, S2, F, Fut, Req, In, Res, Err>
 where
-    A: Service<Req>,
-    B: Service<Result<A::Response, A::Error>>,
-    F: FnMut(A::Response, &mut B) -> Fut,
+    S1: Service<Req>,
+    S2: Service<In>,
+    F: FnMut(S1::Response, &mut S2) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error>,
-    Err: From<B::Error>,
+    Err: From<S1::Error> + From<S2::Error>,
 {
     #[pin]
-    state: State<A, B, F, Fut, Req, Res, Err>,
+    state: State<S1, S2, F, Fut, Req, In, Res, Err>,
 }
 
 #[pin_project::pin_project(project = StateProj)]
-enum State<A, B, F, Fut, Req, Res, Err>
+enum State<S1, S2, F, Fut, Req, In, Res, Err>
 where
-    A: Service<Req>,
-    B: Service<Result<A::Response, A::Error>>,
-    F: FnMut(A::Response, &mut B) -> Fut,
+    S1: Service<Req>,
+    S2: Service<In>,
+    F: FnMut(S1::Response, &mut S2) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error>,
-    Err: From<B::Error>,
+    Err: From<S1::Error> + From<S2::Error>,
 {
-    A(#[pin] A::Future, Option<Rc<RefCell<(A, B, F)>>>),
+    A(#[pin] S1::Future, Option<Rc<RefCell<(S1, S2, F)>>>),
     B(#[pin] Fut),
-    Empty,
+    Empty(PhantomData<In>),
 }
 
-impl<A, B, F, Fut, Req, Res, Err> Future for AndThenApplyFnFuture<A, B, F, Fut, Req, Res, Err>
+impl<S1, S2, F, Fut, Req, In, Res, Err> Future
+    for AndThenApplyFnFuture<S1, S2, F, Fut, Req, In, Res, Err>
 where
-    A: Service<Req>,
-    B: Service<Result<A::Response, A::Error>>,
-    F: FnMut(A::Response, &mut B) -> Fut,
+    S1: Service<Req>,
+    S2: Service<In>,
+    F: FnMut(S1::Response, &mut S2) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<S1::Error> + From<S2::Error>,
 {
     type Output = Result<Res, Err>;
 
@@ -128,8 +129,8 @@ where
         match this.state.as_mut().project() {
             StateProj::A(fut, b) => match fut.poll(cx)? {
                 Poll::Ready(res) => {
-                    let b = b.take().unwrap();
-                    this.state.set(State::Empty);
+                    let b = Option::take(b).unwrap();
+                    this.state.set(State::Empty(PhantomData));
                     let (_, b, f) = &mut *b.borrow_mut();
                     let fut = f(res, b);
                     this.state.set(State::B(fut));
@@ -138,10 +139,10 @@ where
                 Poll::Pending => Poll::Pending,
             },
             StateProj::B(fut) => fut.poll(cx).map(|r| {
-                this.state.set(State::Empty);
+                this.state.set(State::Empty(PhantomData));
                 r
             }),
-            StateProj::Empty => {
+            StateProj::Empty(_) => {
                 panic!("future must not be polled after it returned `Poll::Ready`")
             }
         }
@@ -149,136 +150,127 @@ where
 }
 
 /// `AndThenApplyFn` service factory
-pub(crate) struct AndThenApplyFnFactory<A, B, F, Req, Fut, Res, Err> {
-    srv: Rc<(A, B, F)>,
-    r: PhantomData<(Req, Fut, Res, Err)>,
+pub(crate) struct AndThenApplyFnFactory<SF1, SF2, F, Fut, Req, In, Res, Err> {
+    srv: Rc<(SF1, SF2, F)>,
+    _phantom: PhantomData<(Fut, Req, In, Res, Err)>,
 }
 
-impl<A, B, F, Fut, Req, Res, Err> AndThenApplyFnFactory<A, B, F, Req, Fut, Res, Err>
+impl<SF1, SF2, F, Fut, Req, In, Res, Err>
+    AndThenApplyFnFactory<SF1, SF2, F, Fut, Req, In, Res, Err>
 where
-    A: ServiceFactory<Req>,
-    B: ServiceFactory<
-        Result<A::Response, A::Error>,
-        Config = A::Config,
-        InitError = A::InitError,
-    >,
-    F: FnMut(A::Response, &mut B::Service) -> Fut + Clone,
+    SF1: ServiceFactory<Req>,
+    SF2: ServiceFactory<In, Config = SF1::Config, InitError = SF1::InitError>,
+    F: FnMut(SF1::Response, &mut SF2::Service) -> Fut + Clone,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<SF1::Error> + From<SF2::Error>,
 {
     /// Create new `ApplyNewService` new service instance
-    pub(crate) fn new(a: A, b: B, f: F) -> Self {
+    pub(crate) fn new(a: SF1, b: SF2, wrap_fn: F) -> Self {
         Self {
-            srv: Rc::new((a, b, f)),
-            r: PhantomData,
+            srv: Rc::new((a, b, wrap_fn)),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<A, B, F, Req, Fut, Res, Err> Clone for AndThenApplyFnFactory<A, B, F, Req, Fut, Res, Err> {
+impl<SF1, SF2, F, Fut, Req, In, Res, Err> Clone
+    for AndThenApplyFnFactory<SF1, SF2, F, Fut, Req, In, Res, Err>
+{
     fn clone(&self) -> Self {
         Self {
             srv: self.srv.clone(),
-            r: PhantomData,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<A, B, F, Req, Fut, Res, Err> ServiceFactory<Req>
-    for AndThenApplyFnFactory<A, B, F, Req, Fut, Res, Err>
+impl<SF1, SF2, F, Fut, Req, In, Res, Err> ServiceFactory<Req>
+    for AndThenApplyFnFactory<SF1, SF2, F, Fut, Req, In, Res, Err>
 where
-    A: ServiceFactory<Req>,
-    A::Config: Clone,
-    B: ServiceFactory<
-        Result<A::Response, A::Error>,
-        Config = A::Config,
-        InitError = A::InitError,
-    >,
-    F: FnMut(A::Response, &mut B::Service) -> Fut + Clone,
+    SF1: ServiceFactory<Req>,
+    SF1::Config: Clone,
+    SF2: ServiceFactory<In, Config = SF1::Config, InitError = SF1::InitError>,
+    F: FnMut(SF1::Response, &mut SF2::Service) -> Fut + Clone,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<SF1::Error> + From<SF2::Error>,
 {
     type Response = Res;
     type Error = Err;
-    type Service = AndThenApplyFn<A::Service, B::Service, F, Fut, Req, Res, Err>;
-    type Config = A::Config;
-    type InitError = A::InitError;
-    type Future = AndThenApplyFnFactoryResponse<A, B, F, Fut, Req, Res, Err>;
+    type Service = AndThenApplyFn<SF1::Service, SF2::Service, F, Fut, Req, In, Res, Err>;
+    type Config = SF1::Config;
+    type InitError = SF1::InitError;
+    type Future = AndThenApplyFnFactoryResponse<SF1, SF2, F, Fut, Req, In, Res, Err>;
 
-    fn new_service(&self, cfg: A::Config) -> Self::Future {
+    fn new_service(&self, cfg: SF1::Config) -> Self::Future {
         let srv = &*self.srv;
         AndThenApplyFnFactoryResponse {
-            a: None,
-            b: None,
-            f: srv.2.clone(),
-            fut_a: srv.0.new_service(cfg.clone()),
-            fut_b: srv.1.new_service(cfg),
+            s1: None,
+            s2: None,
+            wrap_fn: srv.2.clone(),
+            fut_s1: srv.0.new_service(cfg.clone()),
+            fut_s2: srv.1.new_service(cfg),
+            _phantom: PhantomData,
         }
     }
 }
 
 #[pin_project::pin_project]
-pub(crate) struct AndThenApplyFnFactoryResponse<A, B, F, Fut, Req, Res, Err>
+pub(crate) struct AndThenApplyFnFactoryResponse<SF1, SF2, F, Fut, Req, In, Res, Err>
 where
-    A: ServiceFactory<Req>,
-    B: ServiceFactory<
-        Result<A::Response, A::Error>,
-        Config = A::Config,
-        InitError = A::InitError,
-    >,
-    F: FnMut(A::Response, &mut B::Service) -> Fut + Clone,
+    SF1: ServiceFactory<Req>,
+    SF2: ServiceFactory<In, Config = SF1::Config, InitError = SF1::InitError>,
+    F: FnMut(SF1::Response, &mut SF2::Service) -> Fut + Clone,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error>,
-    Err: From<B::Error>,
+    Err: From<SF1::Error>,
+    Err: From<SF2::Error>,
 {
     #[pin]
-    fut_b: B::Future,
+    fut_s1: SF1::Future,
     #[pin]
-    fut_a: A::Future,
-    f: F,
-    a: Option<A::Service>,
-    b: Option<B::Service>,
+    fut_s2: SF2::Future,
+    wrap_fn: F,
+    s1: Option<SF1::Service>,
+    s2: Option<SF2::Service>,
+    _phantom: PhantomData<In>,
 }
 
-impl<A, B, F, Fut, Req, Res, Err> Future
-    for AndThenApplyFnFactoryResponse<A, B, F, Fut, Req, Res, Err>
+impl<SF1, SF2, F, Fut, Req, In, Res, Err> Future
+    for AndThenApplyFnFactoryResponse<SF1, SF2, F, Fut, Req, In, Res, Err>
 where
-    A: ServiceFactory<Req>,
-    B: ServiceFactory<
-        Result<A::Response, A::Error>,
-        Config = A::Config,
-        InitError = A::InitError,
-    >,
-    F: FnMut(A::Response, &mut B::Service) -> Fut + Clone,
+    SF1: ServiceFactory<Req>,
+    SF2: ServiceFactory<In, Config = SF1::Config, InitError = SF1::InitError>,
+    F: FnMut(SF1::Response, &mut SF2::Service) -> Fut + Clone,
     Fut: Future<Output = Result<Res, Err>>,
-    Err: From<A::Error> + From<B::Error>,
+    Err: From<SF1::Error> + From<SF2::Error>,
 {
-    type Output =
-        Result<AndThenApplyFn<A::Service, B::Service, F, Fut, Req, Res, Err>, A::InitError>;
+    type Output = Result<
+        AndThenApplyFn<SF1::Service, SF2::Service, F, Fut, Req, In, Res, Err>,
+        SF1::InitError,
+    >;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 
-        if this.a.is_none() {
-            if let Poll::Ready(service) = this.fut_a.poll(cx)? {
-                *this.a = Some(service);
+        if this.s1.is_none() {
+            if let Poll::Ready(service) = this.fut_s1.poll(cx)? {
+                *this.s1 = Some(service);
             }
         }
 
-        if this.b.is_none() {
-            if let Poll::Ready(service) = this.fut_b.poll(cx)? {
-                *this.b = Some(service);
+        if this.s2.is_none() {
+            if let Poll::Ready(service) = this.fut_s2.poll(cx)? {
+                *this.s2 = Some(service);
             }
         }
 
-        if this.a.is_some() && this.b.is_some() {
+        if this.s1.is_some() && this.s2.is_some() {
             Poll::Ready(Ok(AndThenApplyFn {
-                srv: Rc::new(RefCell::new((
-                    this.a.take().unwrap(),
-                    this.b.take().unwrap(),
-                    this.f.clone(),
+                svc: Rc::new(RefCell::new((
+                    Option::take(this.s1).unwrap(),
+                    Option::take(this.s2).unwrap(),
+                    this.wrap_fn.clone(),
                 ))),
-                r: PhantomData,
+                _phantom: PhantomData,
             }))
         } else {
             Poll::Pending
@@ -296,29 +288,29 @@ mod tests {
 
     #[derive(Clone)]
     struct Srv;
-    impl Service<()> for Srv {
+
+    impl Service<u8> for Srv {
         type Response = ();
         type Error = ();
-        type Future = Ready<Result<(), ()>>;
+        type Future = Ready<Result<Self::Response, Self::Error>>;
 
         fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
 
-        #[allow(clippy::unit_arg)]
-        fn call(&mut self, req: ()) -> Self::Future {
-            ok(req)
+        fn call(&mut self, req: u8) -> Self::Future {
+            let _ = req;
+            ok(())
         }
     }
 
     #[actix_rt::test]
     async fn test_service() {
-        let mut srv = pipeline(|| async { Ok(2) })
-            .and_then_apply_fn(Srv, |req: &'static str, s| {
-                s.call(()).map_ok(move |res| (req, res))
-            });
+        let mut srv = pipeline(ok).and_then_apply_fn(Srv, |req: &'static str, s| {
+            s.call(1).map_ok(move |res| (req, res))
+        });
         let res = lazy(|cx| srv.poll_ready(cx)).await;
-        assert_eq!(res, Poll::Ready(Ok(())));
+        assert!(res.is_ready());
 
         let res = srv.call("srv").await;
         assert!(res.is_ok());
@@ -329,11 +321,11 @@ mod tests {
     async fn test_service_factory() {
         let new_srv = pipeline_factory(|| ok::<_, ()>(fn_service(ok))).and_then_apply_fn(
             || ok(Srv),
-            |req: &'static str, s| s.call(()).map_ok(move |res| (req, res)),
+            |req: &'static str, s| s.call(1).map_ok(move |res| (req, res)),
         );
         let mut srv = new_srv.new_service(()).await.unwrap();
         let res = lazy(|cx| srv.poll_ready(cx)).await;
-        assert_eq!(res, Poll::Ready(Ok(())));
+        assert!(res.is_ready());
 
         let res = srv.call("srv").await;
         assert!(res.is_ok());

--- a/actix-service/src/apply.rs
+++ b/actix-service/src/apply.rs
@@ -1,208 +1,209 @@
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::ready;
 
 use super::{IntoService, IntoServiceFactory, Service, ServiceFactory};
 
 /// Apply transform function to a service.
-pub fn apply_fn<T, Req, F, R, In, Out, Err, U>(
+///
+/// The In and Out type params refer to the request and response types for the wrapped service.
+pub fn apply_fn<U, S, F, Fut, Req, In, Res, Err>(
     service: U,
-    f: F,
-) -> Apply<T, Req, F, R, In, Out, Err>
+    wrap_fn: F,
+) -> Apply<S, F, Req, In, Res, Err>
 where
-    T: Service<Req, Error = Err>,
-    F: FnMut(In, &mut T) -> R,
-    R: Future<Output = Result<Out, Err>>,
-    U: IntoService<T, Req>,
+    U: IntoService<S, In>,
+    S: Service<In, Error = Err>,
+    F: FnMut(Req, &mut S) -> Fut,
+    Fut: Future<Output = Result<Res, Err>>,
 {
-    Apply::new(service.into_service(), f)
+    Apply::new(service.into_service(), wrap_fn)
 }
 
 /// Service factory that produces `apply_fn` service.
-pub fn apply_fn_factory<T, Req, F, R, In, Out, Err, U>(
+///
+/// The In and Out type params refer to the request and response types for the wrapped service.
+pub fn apply_fn_factory<U, SF, F, Fut, Req, In, Res, Err>(
     service: U,
     f: F,
-) -> ApplyServiceFactory<T, Req, F, R, In, Out, Err>
+) -> ApplyFactory<SF, F, Req, In, Res, Err>
 where
-    T: ServiceFactory<Req, Error = Err>,
-    F: FnMut(In, &mut T::Service) -> R + Clone,
-    R: Future<Output = Result<Out, Err>>,
-    U: IntoServiceFactory<T, Req>,
+    U: IntoServiceFactory<SF, In>,
+    SF: ServiceFactory<In, Error = Err>,
+    F: FnMut(Req, &mut SF::Service) -> Fut + Clone,
+    Fut: Future<Output = Result<Res, Err>>,
 {
-    ApplyServiceFactory::new(service.into_factory(), f)
+    ApplyFactory::new(service.into_factory(), f)
 }
 
-/// `Apply` service combinator
-pub struct Apply<T, Req, F, R, In, Out, Err>
+/// `Apply` service combinator.
+///
+/// The In and Out type params refer to the request and response types for the wrapped service.
+pub struct Apply<S, F, Req, In, Res, Err>
 where
-    T: Service<Req, Error = Err>,
+    S: Service<In, Error = Err>,
 {
-    service: T,
-    f: F,
-    r: PhantomData<(In, Out, R)>,
+    service: S,
+    wrap_fn: F,
+    _phantom: PhantomData<(Req, In, Res, Err)>,
 }
 
-impl<T, Req, F, R, In, Out, Err> Apply<T, Req, F, R, In, Out, Err>
+impl<S, F, Fut, Req, In, Res, Err> Apply<S, F, Req, In, Res, Err>
 where
-    T: Service<Req, Error = Err>,
-    F: FnMut(In, &mut T) -> R,
-    R: Future<Output = Result<Out, Err>>,
+    S: Service<In, Error = Err>,
+    F: FnMut(Req, &mut S) -> Fut,
+    Fut: Future<Output = Result<Res, Err>>,
 {
     /// Create new `Apply` combinator
-    fn new(service: T, f: F) -> Self {
+    fn new(service: S, wrap_fn: F) -> Self {
         Self {
             service,
-            f,
-            r: PhantomData,
+            wrap_fn,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<T, Req, F, R, In, Out, Err> Clone for Apply<T, Req, F, R, In, Out, Err>
+impl<S, F, Fut, Req, In, Res, Err> Clone for Apply<S, F, Req, In, Res, Err>
 where
-    T: Service<Req, Error = Err> + Clone,
-    F: FnMut(In, &mut T) -> R + Clone,
-    R: Future<Output = Result<Out, Err>>,
+    S: Service<In, Error = Err> + Clone,
+    F: FnMut(Req, &mut S) -> Fut + Clone,
+    Fut: Future<Output = Result<Res, Err>>,
 {
     fn clone(&self) -> Self {
         Apply {
             service: self.service.clone(),
-            f: self.f.clone(),
-            r: PhantomData,
+            wrap_fn: self.wrap_fn.clone(),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<T, Req, F, R, In, Out, Err> Service<Req> for Apply<T, Req, F, R, In, Out, Err>
+impl<S, F, Fut, Req, In, Res, Err> Service<Req> for Apply<S, F, Req, In, Res, Err>
 where
-    T: Service<Req, Error = Err>,
-    F: FnMut(In, &mut T) -> R,
-    R: Future<Output = Result<Out, Err>>,
+    S: Service<In, Error = Err>,
+    F: FnMut(Req, &mut S) -> Fut,
+    Fut: Future<Output = Result<Res, Err>>,
 {
-    // type Request = In;
-    type Response = Out;
+    type Response = Res;
     type Error = Err;
-    type Future = R;
+    type Future = Fut;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(futures_util::ready!(self.service.poll_ready(cx)))
+        Poll::Ready(ready!(self.service.poll_ready(cx)))
     }
 
-    fn call(&mut self, req: In) -> Self::Future {
-        (self.f)(req, &mut self.service)
+    fn call(&mut self, req: Req) -> Self::Future {
+        (self.wrap_fn)(req, &mut self.service)
     }
 }
 
-/// `apply()` service factory
-pub struct ApplyServiceFactory<T, Req, F, R, In, Out, Err>
-where
-    T: ServiceFactory<Req, Error = Err>,
-    F: FnMut(In, &mut T::Service) -> R + Clone,
-    R: Future<Output = Result<Out, Err>>,
-{
-    service: T,
-    f: F,
-    r: PhantomData<(R, In, Out)>,
+/// `ApplyFactory` service factory combinator.
+pub struct ApplyFactory<SF, F, Req, In, Res, Err> {
+    factory: SF,
+    wrap_fn: F,
+    _phantom: PhantomData<(Req, In, Res, Err)>,
 }
 
-impl<T, Req, F, R, In, Out, Err> ApplyServiceFactory<T, Req, F, R, In, Out, Err>
+impl<SF, F, Fut, Req, In, Res, Err> ApplyFactory<SF, F, Req, In, Res, Err>
 where
-    T: ServiceFactory<Req, Error = Err>,
-    F: FnMut(In, &mut T::Service) -> R + Clone,
-    R: Future<Output = Result<Out, Err>>,
+    SF: ServiceFactory<In, Error = Err>,
+    F: FnMut(Req, &mut SF::Service) -> Fut + Clone,
+    Fut: Future<Output = Result<Res, Err>>,
 {
-    /// Create new `ApplyNewService` new service instance
-    fn new(service: T, f: F) -> Self {
+    /// Create new `ApplyFactory` new service instance
+    fn new(factory: SF, wrap_fn: F) -> Self {
         Self {
-            f,
-            service,
-            r: PhantomData,
+            factory,
+            wrap_fn,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<T, Req, F, R, In, Out, Err> Clone for ApplyServiceFactory<T, Req, F, R, In, Out, Err>
+impl<SF, F, Fut, Req, In, Res, Err> Clone for ApplyFactory<SF, F, Req, In, Res, Err>
 where
-    T: ServiceFactory<Req, Error = Err> + Clone,
-    F: FnMut(In, &mut T::Service) -> R + Clone,
-    R: Future<Output = Result<Out, Err>>,
+    SF: ServiceFactory<In, Error = Err> + Clone,
+    F: FnMut(Req, &mut SF::Service) -> Fut + Clone,
+    Fut: Future<Output = Result<Res, Err>>,
 {
     fn clone(&self) -> Self {
         Self {
-            service: self.service.clone(),
-            f: self.f.clone(),
-            r: PhantomData,
+            factory: self.factory.clone(),
+            wrap_fn: self.wrap_fn.clone(),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<T, Req, F, R, In, Out, Err> ServiceFactory<Req>
-    for ApplyServiceFactory<T, Req, F, R, In, Out, Err>
+impl<SF, F, Fut, Req, In, Res, Err> ServiceFactory<Req>
+    for ApplyFactory<SF, F, Req, In, Res, Err>
 where
-    T: ServiceFactory<Req, Error = Err>,
-    F: FnMut(In, &mut T::Service) -> R + Clone,
-    R: Future<Output = Result<Out, Err>>,
+    SF: ServiceFactory<In, Error = Err>,
+    F: FnMut(Req, &mut SF::Service) -> Fut + Clone,
+    Fut: Future<Output = Result<Res, Err>>,
 {
-    // type Request = In;
-    type Response = Out;
+    type Response = Res;
     type Error = Err;
 
-    type Config = T::Config;
-    type Service = Apply<T::Service, Req, F, R, In, Out, Err>;
-    type InitError = T::InitError;
-    type Future = ApplyServiceFactoryResponse<T,Req, F, R, In, Out, Err>;
+    type Config = SF::Config;
+    type Service = Apply<SF::Service, F, Req, In, Res, Err>;
+    type InitError = SF::InitError;
+    type Future = ApplyServiceFactoryResponse<SF, F, Fut, Req, In, Res, Err>;
 
-    fn new_service(&self, cfg: T::Config) -> Self::Future {
-        ApplyServiceFactoryResponse::new(self.service.new_service(cfg), self.f.clone())
+    fn new_service(&self, cfg: SF::Config) -> Self::Future {
+        let svc = self.factory.new_service(cfg);
+        ApplyServiceFactoryResponse::new(svc, self.wrap_fn.clone())
     }
 }
 
 #[pin_project::pin_project]
-pub struct ApplyServiceFactoryResponse<T, Req, F, R, In, Out, Err>
+pub struct ApplyServiceFactoryResponse<SF, F, Fut, Req, In, Res, Err>
 where
-    T: ServiceFactory<Req, Error = Err>,
-    F: FnMut(In, &mut T::Service) -> R,
-    R: Future<Output = Result<Out, Err>>,
+    SF: ServiceFactory<In, Error = Err>,
+    F: FnMut(Req, &mut SF::Service) -> Fut,
+    Fut: Future<Output = Result<Res, Err>>,
 {
     #[pin]
-    fut: T::Future,
-    f: Option<F>,
-    r: PhantomData<(In, Out)>,
+    fut: SF::Future,
+    wrap_fn: Option<F>,
+    _phantom: PhantomData<(Req, Res)>,
 }
 
-impl<T, Req, F, R, In, Out, Err> ApplyServiceFactoryResponse<T, Req, F, R, In, Out, Err>
+impl<SF, F, Fut, Req, In, Res, Err> ApplyServiceFactoryResponse<SF, F, Fut, Req, In, Res, Err>
 where
-    T: ServiceFactory<Req, Error = Err>,
-    F: FnMut(In, &mut T::Service) -> R,
-    R: Future<Output = Result<Out, Err>>,
+    SF: ServiceFactory<In, Error = Err>,
+    F: FnMut(Req, &mut SF::Service) -> Fut,
+    Fut: Future<Output = Result<Res, Err>>,
 {
-    fn new(fut: T::Future, f: F) -> Self {
+    fn new(fut: SF::Future, wrap_fn: F) -> Self {
         Self {
-            f: Some(f),
             fut,
-            r: PhantomData,
+            wrap_fn: Some(wrap_fn),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<T, Req, F, R, In, Out, Err> Future
-    for ApplyServiceFactoryResponse<T, Req, F, R, In, Out, Err>
+impl<SF, F, Fut, Req, In, Res, Err> Future
+    for ApplyServiceFactoryResponse<SF, F, Fut, Req, In, Res, Err>
 where
-    T: ServiceFactory<Req, Error = Err>,
-    F: FnMut(In, &mut T::Service) -> R,
-    R: Future<Output = Result<Out, Err>>,
+    SF: ServiceFactory<In, Error = Err>,
+    F: FnMut(Req, &mut SF::Service) -> Fut,
+    Fut: Future<Output = Result<Res, Err>>,
 {
-    type Output = Result<Apply<T::Service, Req, F, R, In, Out, Err>, T::InitError>;
+    type Output = Result<Apply<SF::Service, F, Req, In, Res, Err>, SF::InitError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 
-        if let Poll::Ready(svc) = this.fut.poll(cx)? {
-            Poll::Ready(Ok(Apply::new(svc, this.f.take().unwrap())))
-        } else {
-            Poll::Pending
-        }
+        let svc = ready!(this.fut.poll(cx))?;
+        Poll::Ready(Ok(Apply::new(svc, Option::take(this.wrap_fn).unwrap())))
     }
 }
 

--- a/actix-service/src/apply.rs
+++ b/actix-service/src/apply.rs
@@ -12,12 +12,12 @@ use super::{IntoService, IntoServiceFactory, Service, ServiceFactory};
 /// Apply transform function to a service.
 ///
 /// The In and Out type params refer to the request and response types for the wrapped service.
-pub fn apply_fn<U, S, F, Fut, Req, In, Res, Err>(
-    service: U,
+pub fn apply_fn<I, S, F, Fut, Req, In, Res, Err>(
+    service: I,
     wrap_fn: F,
 ) -> Apply<S, F, Req, In, Res, Err>
 where
-    U: IntoService<S, In>,
+    I: IntoService<S, In>,
     S: Service<In, Error = Err>,
     F: FnMut(Req, &mut S) -> Fut,
     Fut: Future<Output = Result<Res, Err>>,
@@ -28,12 +28,12 @@ where
 /// Service factory that produces `apply_fn` service.
 ///
 /// The In and Out type params refer to the request and response types for the wrapped service.
-pub fn apply_fn_factory<U, SF, F, Fut, Req, In, Res, Err>(
-    service: U,
+pub fn apply_fn_factory<I, SF, F, Fut, Req, In, Res, Err>(
+    service: I,
     f: F,
 ) -> ApplyFactory<SF, F, Req, In, Res, Err>
 where
-    U: IntoServiceFactory<SF, In>,
+    I: IntoServiceFactory<SF, In>,
     SF: ServiceFactory<In, Error = Err>,
     F: FnMut(Req, &mut SF::Service) -> Fut + Clone,
     Fut: Future<Output = Result<Res, Err>>,

--- a/actix-service/src/apply_cfg.rs
+++ b/actix-service/src/apply_cfg.rs
@@ -68,7 +68,7 @@ where
     S: Service<Req>,
 {
     srv: Rc<RefCell<(T, F)>>,
-    _t: PhantomData<(C, R, S)>,
+    _t: PhantomData<(C, Req, R, S)>,
 }
 
 impl<F, C, Req, T, R, S, E> Clone for ApplyConfigService<F, C, Req, T, R, S, E>
@@ -116,7 +116,7 @@ where
     S: Service<Req>,
 {
     srv: Rc<RefCell<(T, F)>>,
-    _t: PhantomData<(C, R, S)>,
+    _t: PhantomData<(C, Req, R, S)>,
 }
 
 impl<F, C, Req, T, R, S> Clone for ApplyConfigServiceFactory<F, C, Req, T, R, S>

--- a/actix-service/src/fn_service.rs
+++ b/actix-service/src/fn_service.rs
@@ -55,7 +55,7 @@ where
 /// ```
 pub fn fn_factory<F, Cfg, Srv, Req, Fut, Err>(
     f: F,
-) -> FnServiceNoConfig<F, Cfg, Srv, Fut, Req, Err>
+) -> FnServiceNoConfig<F, Cfg, Srv, Req, Fut, Err>
 where
     Srv: Service<Req>,
     F: Fn() -> Fut,
@@ -247,7 +247,7 @@ where
     Srv: Service<Req>,
 {
     f: F,
-    _t: PhantomData<(Fut, Cfg, Srv, Err)>,
+    _t: PhantomData<(Fut, Cfg, Req, Srv, Err)>,
 }
 
 impl<F, Fut, Cfg, Srv, Req, Err> FnServiceConfig<F, Fut, Cfg, Srv, Req, Err>
@@ -303,7 +303,7 @@ where
     Fut: Future<Output = Result<Srv, Err>>,
 {
     f: F,
-    _t: PhantomData<Cfg>,
+    _t: PhantomData<(Cfg, Req)>,
 }
 
 impl<F, Cfg, Srv, Req, Fut, Err> FnServiceNoConfig<F, Cfg, Srv, Req, Fut, Err>

--- a/actix-service/src/lib.rs
+++ b/actix-service/src/lib.rs
@@ -338,10 +338,10 @@ where
     }
 }
 
-/// Convert object of type `T` to a service `S`
-pub fn into_service<U, S, Req>(tp: U) -> S
+/// Convert object of type `U` to a service `S`
+pub fn into_service<I, S, Req>(tp: I) -> S
 where
-    U: IntoService<S, Req>,
+    I: IntoService<S, Req>,
     S: Service<Req>,
 {
     tp.into_service()

--- a/actix-service/src/lib.rs
+++ b/actix-service/src/lib.rs
@@ -303,52 +303,52 @@ where
 }
 
 /// Trait for types that can be converted to a `Service`
-pub trait IntoService<T, Req>
+pub trait IntoService<S, Req>
 where
-    T: Service<Req>,
+    S: Service<Req>,
 {
     /// Convert to a `Service`
-    fn into_service(self) -> T;
+    fn into_service(self) -> S;
 }
 
 /// Trait for types that can be converted to a `ServiceFactory`
-pub trait IntoServiceFactory<T, Req>
+pub trait IntoServiceFactory<SF, Req>
 where
-    T: ServiceFactory<Req>,
+    SF: ServiceFactory<Req>,
 {
     /// Convert `Self` to a `ServiceFactory`
-    fn into_factory(self) -> T;
+    fn into_factory(self) -> SF;
 }
 
-impl<T, Req> IntoService<T, Req> for T
+impl<S, Req> IntoService<S, Req> for S
 where
-    T: Service<Req>,
+    S: Service<Req>,
 {
-    fn into_service(self) -> T {
+    fn into_service(self) -> S {
         self
     }
 }
 
-impl<T, Req> IntoServiceFactory<T, Req> for T
+impl<SF, Req> IntoServiceFactory<SF, Req> for SF
 where
-    T: ServiceFactory<Req>,
+    SF: ServiceFactory<Req>,
 {
-    fn into_factory(self) -> T {
+    fn into_factory(self) -> SF {
         self
     }
 }
 
 /// Convert object of type `T` to a service `S`
-pub fn into_service<T, S, Req>(tp: T) -> S
+pub fn into_service<U, S, Req>(tp: U) -> S
 where
+    U: IntoService<S, Req>,
     S: Service<Req>,
-    T: IntoService<S, Req>,
 {
     tp.into_service()
 }
 
 pub mod dev {
-    pub use crate::apply::{Apply, ApplyServiceFactory};
+    pub use crate::apply::{Apply, ApplyFactory};
     pub use crate::fn_service::{
         FnService, FnServiceConfig, FnServiceFactory, FnServiceNoConfig,
     };

--- a/actix-service/src/map.rs
+++ b/actix-service/src/map.rs
@@ -8,18 +8,18 @@ use super::{Service, ServiceFactory};
 /// Service for the `map` combinator, changing the type of a service's response.
 ///
 /// This is created by the `ServiceExt::map` method.
-pub struct Map<A, F, Response> {
+pub struct Map<A, F, Req, Res> {
     service: A,
     f: F,
-    _t: PhantomData<Response>,
+    _t: PhantomData<(Req, Res)>,
 }
 
-impl<A, F, Response> Map<A, F, Response> {
+impl<A, F, Req, Res> Map<A, F, Req, Res> {
     /// Create new `Map` combinator
     pub(crate) fn new(service: A, f: F) -> Self
     where
-        A: Service,
-        F: FnMut(A::Response) -> Response,
+        A: Service<Req>,
+        F: FnMut(A::Response) -> Res,
     {
         Self {
             service,
@@ -29,7 +29,7 @@ impl<A, F, Response> Map<A, F, Response> {
     }
 }
 
-impl<A, F, Response> Clone for Map<A, F, Response>
+impl<A, F, Req, Res> Clone for Map<A, F, Req, Res>
 where
     A: Clone,
     F: Clone,
@@ -43,52 +43,51 @@ where
     }
 }
 
-impl<A, F, Response> Service for Map<A, F, Response>
+impl<A, F, Req, Res> Service<Req> for Map<A, F, Req, Res>
 where
-    A: Service,
-    F: FnMut(A::Response) -> Response + Clone,
+    A: Service<Req>,
+    F: FnMut(A::Response) -> Res + Clone,
 {
-    type Request = A::Request;
-    type Response = Response;
+    type Response = Res;
     type Error = A::Error;
-    type Future = MapFuture<A, F, Response>;
+    type Future = MapFuture<A, F, Req, Res>;
 
     fn poll_ready(&mut self, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.service.poll_ready(ctx)
     }
 
-    fn call(&mut self, req: A::Request) -> Self::Future {
+    fn call(&mut self, req: Req) -> Self::Future {
         MapFuture::new(self.service.call(req), self.f.clone())
     }
 }
 
 #[pin_project::pin_project]
-pub struct MapFuture<A, F, Response>
+pub struct MapFuture<A, F, Req, Res>
 where
-    A: Service,
-    F: FnMut(A::Response) -> Response,
+    A: Service<Req>,
+    F: FnMut(A::Response) -> Res,
 {
     f: F,
     #[pin]
     fut: A::Future,
 }
 
-impl<A, F, Response> MapFuture<A, F, Response>
+impl<A, F, Req, Res> MapFuture<A, F, Req, Res>
 where
-    A: Service,
-    F: FnMut(A::Response) -> Response,
+    A: Service<Req>,
+    F: FnMut(A::Response) -> Res,
 {
     fn new(fut: A::Future, f: F) -> Self {
         MapFuture { f, fut }
     }
 }
 
-impl<A, F, Response> Future for MapFuture<A, F, Response>
+impl<A, F, Req, Res> Future for MapFuture<A, F, Req, Res>
 where
-    A: Service,
-    F: FnMut(A::Response) -> Response,
+    A: Service<Req>,
+    F: FnMut(A::Response) -> Res,
 {
-    type Output = Result<Response, A::Error>;
+    type Output = Result<Res, A::Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -102,17 +101,17 @@ where
 }
 
 /// `MapNewService` new service combinator
-pub struct MapServiceFactory<A, F, Res> {
+pub struct MapServiceFactory<A, F, Req, Res> {
     a: A,
     f: F,
     r: PhantomData<Res>,
 }
 
-impl<A, F, Res> MapServiceFactory<A, F, Res> {
+impl<A, F, Req, Res> MapServiceFactory<A, F, Req, Res> {
     /// Create new `Map` new service instance
     pub(crate) fn new(a: A, f: F) -> Self
     where
-        A: ServiceFactory,
+        A: ServiceFactory<Req>,
         F: FnMut(A::Response) -> Res,
     {
         Self {
@@ -123,7 +122,7 @@ impl<A, F, Res> MapServiceFactory<A, F, Res> {
     }
 }
 
-impl<A, F, Res> Clone for MapServiceFactory<A, F, Res>
+impl<A, F, Req, Res> Clone for MapServiceFactory<A, F, Req, Res>
 where
     A: Clone,
     F: Clone,
@@ -137,19 +136,18 @@ where
     }
 }
 
-impl<A, F, Res> ServiceFactory for MapServiceFactory<A, F, Res>
+impl<A, F, Req, Res> ServiceFactory<Req> for MapServiceFactory<A, F, Req, Res>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: FnMut(A::Response) -> Res + Clone,
 {
-    type Request = A::Request;
     type Response = Res;
     type Error = A::Error;
 
     type Config = A::Config;
-    type Service = Map<A::Service, F, Res>;
+    type Service = Map<A::Service, F, Req, Res>;
     type InitError = A::InitError;
-    type Future = MapServiceFuture<A, F, Res>;
+    type Future = MapServiceFuture<A, F, Req, Res>;
 
     fn new_service(&self, cfg: A::Config) -> Self::Future {
         MapServiceFuture::new(self.a.new_service(cfg), self.f.clone())
@@ -157,9 +155,9 @@ where
 }
 
 #[pin_project::pin_project]
-pub struct MapServiceFuture<A, F, Res>
+pub struct MapServiceFuture<A, F, Req, Res>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: FnMut(A::Response) -> Res,
 {
     #[pin]
@@ -167,9 +165,9 @@ where
     f: Option<F>,
 }
 
-impl<A, F, Res> MapServiceFuture<A, F, Res>
+impl<A, F, Req, Res> MapServiceFuture<A, F, Req, Res>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: FnMut(A::Response) -> Res,
 {
     fn new(fut: A::Future, f: F) -> Self {
@@ -177,12 +175,12 @@ where
     }
 }
 
-impl<A, F, Res> Future for MapServiceFuture<A, F, Res>
+impl<A, F, Req, Res> Future for MapServiceFuture<A, F, Req, Res>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: FnMut(A::Response) -> Res,
 {
-    type Output = Result<Map<A::Service, F, Res>, A::InitError>;
+    type Output = Result<Map<A::Service, F, Req, Res>, A::InitError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -204,8 +202,7 @@ mod tests {
 
     struct Srv;
 
-    impl Service for Srv {
-        type Request = ();
+    impl Service<()> for Srv {
         type Response = ();
         type Error = ();
         type Future = Ready<Result<(), ()>>;

--- a/actix-service/src/map.rs
+++ b/actix-service/src/map.rs
@@ -104,7 +104,7 @@ where
 pub struct MapServiceFactory<A, F, Req, Res> {
     a: A,
     f: F,
-    r: PhantomData<Res>,
+    r: PhantomData<(Res, Req)>,
 }
 
 impl<A, F, Req, Res> MapServiceFactory<A, F, Req, Res> {

--- a/actix-service/src/map_config.rs
+++ b/actix-service/src/map_config.rs
@@ -6,9 +6,9 @@ use super::{IntoServiceFactory, ServiceFactory};
 ///
 /// Note that this function consumes the receiving service factory and returns
 /// a wrapped version of it.
-pub fn map_config<U, SF, S, Req, F, Cfg>(factory: U, f: F) -> MapConfig<SF, Req, F, Cfg>
+pub fn map_config<I, SF, S, Req, F, Cfg>(factory: I, f: F) -> MapConfig<SF, Req, F, Cfg>
 where
-    U: IntoServiceFactory<SF, Req>,
+    I: IntoServiceFactory<SF, Req>,
     SF: ServiceFactory<Req>,
     F: Fn(Cfg) -> SF::Config,
 {
@@ -16,9 +16,9 @@ where
 }
 
 /// Replace config with unit.
-pub fn unit_config<U, SF, Cfg, Req>(factory: U) -> UnitConfig<SF, Cfg, Req>
+pub fn unit_config<I, SF, Cfg, Req>(factory: I) -> UnitConfig<SF, Cfg, Req>
 where
-    U: IntoServiceFactory<SF, Req>,
+    I: IntoServiceFactory<SF, Req>,
     SF: ServiceFactory<Req, Config = ()>,
 {
     UnitConfig::new(factory.into_factory())

--- a/actix-service/src/map_err.rs
+++ b/actix-service/src/map_err.rs
@@ -9,18 +9,18 @@ use super::{Service, ServiceFactory};
 /// error.
 ///
 /// This is created by the `ServiceExt::map_err` method.
-pub struct MapErr<A, F, E> {
-    service: A,
+pub struct MapErr<S, Req, F, E> {
+    service: S,
     f: F,
     _t: PhantomData<E>,
 }
 
-impl<A, F, E> MapErr<A, F, E> {
+impl<S, Req, F, E> MapErr<S, Req, F, E> {
     /// Create new `MapErr` combinator
-    pub(crate) fn new(service: A, f: F) -> Self
+    pub(crate) fn new(service: S, f: F) -> Self
     where
-        A: Service,
-        F: Fn(A::Error) -> E,
+        S: Service<Req>,
+        F: Fn(S::Error) -> E,
     {
         Self {
             service,
@@ -30,9 +30,9 @@ impl<A, F, E> MapErr<A, F, E> {
     }
 }
 
-impl<A, F, E> Clone for MapErr<A, F, E>
+impl<S, Req, F, E> Clone for MapErr<S, Req, F, E>
 where
-    A: Clone,
+    S: Clone,
     F: Clone,
 {
     fn clone(&self) -> Self {
@@ -44,29 +44,28 @@ where
     }
 }
 
-impl<A, F, E> Service for MapErr<A, F, E>
+impl<A, Req, F, E> Service<Req> for MapErr<A, Req, F, E>
 where
-    A: Service,
+    A: Service<Req>,
     F: Fn(A::Error) -> E + Clone,
 {
-    type Request = A::Request;
     type Response = A::Response;
     type Error = E;
-    type Future = MapErrFuture<A, F, E>;
+    type Future = MapErrFuture<A, Req, F, E>;
 
     fn poll_ready(&mut self, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.service.poll_ready(ctx).map_err(&self.f)
     }
 
-    fn call(&mut self, req: A::Request) -> Self::Future {
+    fn call(&mut self, req: Req) -> Self::Future {
         MapErrFuture::new(self.service.call(req), self.f.clone())
     }
 }
 
 #[pin_project::pin_project]
-pub struct MapErrFuture<A, F, E>
+pub struct MapErrFuture<A, Req, F, E>
 where
-    A: Service,
+    A: Service<Req>,
     F: Fn(A::Error) -> E,
 {
     f: F,
@@ -74,9 +73,9 @@ where
     fut: A::Future,
 }
 
-impl<A, F, E> MapErrFuture<A, F, E>
+impl<A, Req, F, E> MapErrFuture<A, Req, F, E>
 where
-    A: Service,
+    A: Service<Req>,
     F: Fn(A::Error) -> E,
 {
     fn new(fut: A::Future, f: F) -> Self {
@@ -84,9 +83,9 @@ where
     }
 }
 
-impl<A, F, E> Future for MapErrFuture<A, F, E>
+impl<A, Req, F, E> Future for MapErrFuture<A, Req, F, E>
 where
-    A: Service,
+    A: Service<Req>,
     F: Fn(A::Error) -> E,
 {
     type Output = Result<A::Response, E>;
@@ -101,9 +100,9 @@ where
 /// service's error.
 ///
 /// This is created by the `NewServiceExt::map_err` method.
-pub struct MapErrServiceFactory<A, F, E>
+pub struct MapErrServiceFactory<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::Error) -> E + Clone,
 {
     a: A,
@@ -111,9 +110,9 @@ where
     e: PhantomData<E>,
 }
 
-impl<A, F, E> MapErrServiceFactory<A, F, E>
+impl<A, Req, F, E> MapErrServiceFactory<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::Error) -> E + Clone,
 {
     /// Create new `MapErr` new service instance
@@ -126,9 +125,9 @@ where
     }
 }
 
-impl<A, F, E> Clone for MapErrServiceFactory<A, F, E>
+impl<A, Req, F, E> Clone for MapErrServiceFactory<A, Req, F, E>
 where
-    A: ServiceFactory + Clone,
+    A: ServiceFactory<Req> + Clone,
     F: Fn(A::Error) -> E + Clone,
 {
     fn clone(&self) -> Self {
@@ -140,19 +139,18 @@ where
     }
 }
 
-impl<A, F, E> ServiceFactory for MapErrServiceFactory<A, F, E>
+impl<A, Req, F, E> ServiceFactory<Req> for MapErrServiceFactory<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::Error) -> E + Clone,
 {
-    type Request = A::Request;
     type Response = A::Response;
     type Error = E;
 
     type Config = A::Config;
-    type Service = MapErr<A::Service, F, E>;
+    type Service = MapErr<A::Service, Req, F, E>;
     type InitError = A::InitError;
-    type Future = MapErrServiceFuture<A, F, E>;
+    type Future = MapErrServiceFuture<A, Req, F, E>;
 
     fn new_service(&self, cfg: A::Config) -> Self::Future {
         MapErrServiceFuture::new(self.a.new_service(cfg), self.f.clone())
@@ -160,9 +158,9 @@ where
 }
 
 #[pin_project::pin_project]
-pub struct MapErrServiceFuture<A, F, E>
+pub struct MapErrServiceFuture<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::Error) -> E,
 {
     #[pin]
@@ -170,9 +168,9 @@ where
     f: F,
 }
 
-impl<A, F, E> MapErrServiceFuture<A, F, E>
+impl<A, Req, F, E> MapErrServiceFuture<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::Error) -> E,
 {
     fn new(fut: A::Future, f: F) -> Self {
@@ -180,12 +178,12 @@ where
     }
 }
 
-impl<A, F, E> Future for MapErrServiceFuture<A, F, E>
+impl<A, Req, F, E> Future for MapErrServiceFuture<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::Error) -> E + Clone,
 {
-    type Output = Result<MapErr<A::Service, F, E>, A::InitError>;
+    type Output = Result<MapErr<A::Service, Req, F, E>, A::InitError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -206,8 +204,7 @@ mod tests {
 
     struct Srv;
 
-    impl Service for Srv {
-        type Request = ();
+    impl Service<()> for Srv {
         type Response = ();
         type Error = ();
         type Future = Ready<Result<(), ()>>;

--- a/actix-service/src/map_err.rs
+++ b/actix-service/src/map_err.rs
@@ -12,7 +12,7 @@ use super::{Service, ServiceFactory};
 pub struct MapErr<S, Req, F, E> {
     service: S,
     f: F,
-    _t: PhantomData<E>,
+    _t: PhantomData<(E, Req)>,
 }
 
 impl<S, Req, F, E> MapErr<S, Req, F, E> {
@@ -107,7 +107,7 @@ where
 {
     a: A,
     f: F,
-    e: PhantomData<E>,
+    e: PhantomData<(E, Req)>,
 }
 
 impl<A, Req, F, E> MapErrServiceFactory<A, Req, F, E>

--- a/actix-service/src/map_init_err.rs
+++ b/actix-service/src/map_init_err.rs
@@ -12,7 +12,7 @@ pub struct MapInitErr<A, F, Req, Err> {
     e: PhantomData<(Req, Err)>,
 }
 
-impl<A, Req, F, Err> MapInitErr<A, Req, F, Err>
+impl<A, F, Req, Err> MapInitErr<A, F, Req, Err>
 where
     A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> Err,
@@ -41,7 +41,7 @@ where
     }
 }
 
-impl<A, Req, F, E> ServiceFactory<Req> for MapInitErr<A, Req, F, E>
+impl<A, F, Req, E> ServiceFactory<Req> for MapInitErr<A, F, Req, E>
 where
     A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E + Clone,
@@ -52,7 +52,7 @@ where
     type Config = A::Config;
     type Service = A::Service;
     type InitError = E;
-    type Future = MapInitErrFuture<A, Req, F, E>;
+    type Future = MapInitErrFuture<A, F, Req, E>;
 
     fn new_service(&self, cfg: A::Config) -> Self::Future {
         MapInitErrFuture::new(self.a.new_service(cfg), self.f.clone())
@@ -60,7 +60,7 @@ where
 }
 
 #[pin_project::pin_project]
-pub struct MapInitErrFuture<A, Req, F, E>
+pub struct MapInitErrFuture<A, F, Req, E>
 where
     A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E,
@@ -70,7 +70,7 @@ where
     fut: A::Future,
 }
 
-impl<A, Req, F, E> MapInitErrFuture<A, Req, F, E>
+impl<A, F, Req, E> MapInitErrFuture<A, F, Req, E>
 where
     A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E,
@@ -80,7 +80,7 @@ where
     }
 }
 
-impl<A, Req, F, E> Future for MapInitErrFuture<A, Req, F, E>
+impl<A, F, Req, E> Future for MapInitErrFuture<A, F, Req, E>
 where
     A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E,

--- a/actix-service/src/map_init_err.rs
+++ b/actix-service/src/map_init_err.rs
@@ -6,16 +6,16 @@ use std::task::{Context, Poll};
 use super::ServiceFactory;
 
 /// `MapInitErr` service combinator
-pub struct MapInitErr<A, F, E> {
+pub struct MapInitErr<A, F, Req, Err> {
     a: A,
     f: F,
-    e: PhantomData<E>,
+    e: PhantomData<(Req, Err)>,
 }
 
-impl<A, F, E> MapInitErr<A, F, E>
+impl<A, Req, F, Err> MapInitErr<A, Req, F, Err>
 where
-    A: ServiceFactory,
-    F: Fn(A::InitError) -> E,
+    A: ServiceFactory<Req>,
+    F: Fn(A::InitError) -> Err,
 {
     /// Create new `MapInitErr` combinator
     pub(crate) fn new(a: A, f: F) -> Self {
@@ -27,7 +27,7 @@ where
     }
 }
 
-impl<A, F, E> Clone for MapInitErr<A, F, E>
+impl<A, F, Req, E> Clone for MapInitErr<A, F, Req, E>
 where
     A: Clone,
     F: Clone,
@@ -41,19 +41,18 @@ where
     }
 }
 
-impl<A, F, E> ServiceFactory for MapInitErr<A, F, E>
+impl<A, Req, F, E> ServiceFactory<Req> for MapInitErr<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E + Clone,
 {
-    type Request = A::Request;
     type Response = A::Response;
     type Error = A::Error;
 
     type Config = A::Config;
     type Service = A::Service;
     type InitError = E;
-    type Future = MapInitErrFuture<A, F, E>;
+    type Future = MapInitErrFuture<A, Req, F, E>;
 
     fn new_service(&self, cfg: A::Config) -> Self::Future {
         MapInitErrFuture::new(self.a.new_service(cfg), self.f.clone())
@@ -61,9 +60,9 @@ where
 }
 
 #[pin_project::pin_project]
-pub struct MapInitErrFuture<A, F, E>
+pub struct MapInitErrFuture<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E,
 {
     f: F,
@@ -71,9 +70,9 @@ where
     fut: A::Future,
 }
 
-impl<A, F, E> MapInitErrFuture<A, F, E>
+impl<A, Req, F, E> MapInitErrFuture<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E,
 {
     fn new(fut: A::Future, f: F) -> Self {
@@ -81,9 +80,9 @@ where
     }
 }
 
-impl<A, F, E> Future for MapInitErrFuture<A, F, E>
+impl<A, Req, F, E> Future for MapInitErrFuture<A, Req, F, E>
 where
-    A: ServiceFactory,
+    A: ServiceFactory<Req>,
     F: Fn(A::InitError) -> E,
 {
     type Output = Result<A::Service, E>;

--- a/actix-service/src/transform.rs
+++ b/actix-service/src/transform.rs
@@ -1,18 +1,18 @@
-use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::{future::Future, marker::PhantomData};
 
 use crate::transform_err::TransformMapInitErr;
 use crate::{IntoServiceFactory, Service, ServiceFactory};
 
 /// Apply transform to a service.
-pub fn apply<T, S, U>(t: T, factory: U) -> ApplyTransform<T, S>
+pub fn apply<T, S, U, Req>(t: T, factory: U) -> ApplyTransform<T, S, Req>
 where
-    S: ServiceFactory,
-    T: Transform<S::Service, InitError = S::InitError>,
-    U: IntoServiceFactory<S>,
+    S: ServiceFactory<Req>,
+    T: Transform<S::Service, Req, InitError = S::InitError>,
+    U: IntoServiceFactory<S, Req>,
 {
     ApplyTransform::new(t, factory.into_factory())
 }
@@ -89,10 +89,7 @@ where
 ///     }
 /// }
 /// ```
-pub trait Transform<S> {
-    /// Requests handled by the service.
-    type Request;
-
+pub trait Transform<S, Req> {
     /// Responses given by the service.
     type Response;
 
@@ -100,11 +97,7 @@ pub trait Transform<S> {
     type Error;
 
     /// The `TransformService` value created by this factory
-    type Transform: Service<
-        Request = Self::Request,
-        Response = Self::Response,
-        Error = Self::Error,
-    >;
+    type Transform: Service<Req, Response = Self::Response, Error = Self::Error>;
 
     /// Errors produced while building a transform service.
     type InitError;
@@ -117,7 +110,7 @@ pub trait Transform<S> {
 
     /// Map this transform's factory error to a different error,
     /// returning a new transform service factory.
-    fn map_init_err<F, E>(self, f: F) -> TransformMapInitErr<Self, S, F, E>
+    fn map_init_err<F, E>(self, f: F) -> TransformMapInitErr<Self, S, Req, F, E>
     where
         Self: Sized,
         F: Fn(Self::InitError) -> E + Clone,
@@ -126,11 +119,10 @@ pub trait Transform<S> {
     }
 }
 
-impl<T, S> Transform<S> for Rc<T>
+impl<T, S, Req> Transform<S, Req> for Rc<T>
 where
-    T: Transform<S>,
+    T: Transform<S, Req>,
 {
-    type Request = T::Request;
     type Response = T::Response;
     type Error = T::Error;
     type InitError = T::InitError;
@@ -142,11 +134,10 @@ where
     }
 }
 
-impl<T, S> Transform<S> for Arc<T>
+impl<T, S, Req> Transform<S, Req> for Arc<T>
 where
-    T: Transform<S>,
+    T: Transform<S, Req>,
 {
-    type Request = T::Request;
     type Response = T::Response;
     type Error = T::Error;
     type InitError = T::InitError;
@@ -159,38 +150,37 @@ where
 }
 
 /// `Apply` transform to new service
-pub struct ApplyTransform<T, S>(Rc<(T, S)>);
+pub struct ApplyTransform<T, S, Req>(Rc<(T, S)>, PhantomData<Req>);
 
-impl<T, S> ApplyTransform<T, S>
+impl<T, S, Req> ApplyTransform<T, S, Req>
 where
-    S: ServiceFactory,
-    T: Transform<S::Service, InitError = S::InitError>,
+    S: ServiceFactory<Req>,
+    T: Transform<S::Service, Req, InitError = S::InitError>,
 {
     /// Create new `ApplyTransform` new service instance
     fn new(t: T, service: S) -> Self {
-        Self(Rc::new((t, service)))
+        Self(Rc::new((t, service)), PhantomData)
     }
 }
 
-impl<T, S> Clone for ApplyTransform<T, S> {
+impl<T, S, Req> Clone for ApplyTransform<T, S, Req> {
     fn clone(&self) -> Self {
-        ApplyTransform(self.0.clone())
+        ApplyTransform(self.0.clone(), PhantomData)
     }
 }
 
-impl<T, S> ServiceFactory for ApplyTransform<T, S>
+impl<T, S, Req> ServiceFactory<Req> for ApplyTransform<T, S, Req>
 where
-    S: ServiceFactory,
-    T: Transform<S::Service, InitError = S::InitError>,
+    S: ServiceFactory<Req>,
+    T: Transform<S::Service, Req, InitError = S::InitError>,
 {
-    type Request = T::Request;
     type Response = T::Response;
     type Error = T::Error;
 
     type Config = S::Config;
     type Service = T::Transform;
     type InitError = T::InitError;
-    type Future = ApplyTransformFuture<T, S>;
+    type Future = ApplyTransformFuture<T, S, Req>;
 
     fn new_service(&self, cfg: S::Config) -> Self::Future {
         ApplyTransformFuture {
@@ -201,30 +191,30 @@ where
 }
 
 #[pin_project::pin_project]
-pub struct ApplyTransformFuture<T, S>
+pub struct ApplyTransformFuture<T, S, Req>
 where
-    S: ServiceFactory,
-    T: Transform<S::Service, InitError = S::InitError>,
+    S: ServiceFactory<Req>,
+    T: Transform<S::Service, Req, InitError = S::InitError>,
 {
     store: Rc<(T, S)>,
     #[pin]
-    state: ApplyTransformFutureState<T, S>,
+    state: ApplyTransformFutureState<T, S, Req>,
 }
 
 #[pin_project::pin_project(project = ApplyTransformFutureStateProj)]
-pub enum ApplyTransformFutureState<T, S>
+pub enum ApplyTransformFutureState<T, S, Req>
 where
-    S: ServiceFactory,
-    T: Transform<S::Service, InitError = S::InitError>,
+    S: ServiceFactory<Req>,
+    T: Transform<S::Service, Req, InitError = S::InitError>,
 {
     A(#[pin] S::Future),
     B(#[pin] T::Future),
 }
 
-impl<T, S> Future for ApplyTransformFuture<T, S>
+impl<T, S, Req> Future for ApplyTransformFuture<T, S, Req>
 where
-    S: ServiceFactory,
-    T: Transform<S::Service, InitError = S::InitError>,
+    S: ServiceFactory<Req>,
+    T: Transform<S::Service, Req, InitError = S::InitError>,
 {
     type Output = Result<T::Transform, T::InitError>;
 

--- a/actix-service/src/transform.rs
+++ b/actix-service/src/transform.rs
@@ -8,11 +8,11 @@ use crate::transform_err::TransformMapInitErr;
 use crate::{IntoServiceFactory, Service, ServiceFactory};
 
 /// Apply transform to a service.
-pub fn apply<T, S, U, Req>(t: T, factory: U) -> ApplyTransform<T, S, Req>
+pub fn apply<T, S, I, Req>(t: T, factory: I) -> ApplyTransform<T, S, Req>
 where
+    I: IntoServiceFactory<S, Req>,
     S: ServiceFactory<Req>,
     T: Transform<S::Service, Req, InitError = S::InitError>,
-    U: IntoServiceFactory<S, Req>,
 {
     ApplyTransform::new(t, factory.into_factory())
 }

--- a/actix-tracing/src/lib.rs
+++ b/actix-tracing/src/lib.rs
@@ -103,14 +103,14 @@ where
 ///     |req: &Request| Some(span!(Level::INFO, "request", req.id))
 /// );
 /// ```
-pub fn trace<S, Req, U, F>(
-    service_factory: U,
+pub fn trace<S, Req, I, F>(
+    service_factory: I,
     make_span: F,
 ) -> ApplyTransform<TracingTransform<S::Service, S, F>, S, Req>
 where
+    I: IntoServiceFactory<S, Req>,
     S: ServiceFactory<Req>,
     F: Fn(&Req) -> Option<tracing::Span> + Clone,
-    U: IntoServiceFactory<S, Req>,
 {
     apply(
         TracingTransform::new(make_span),

--- a/actix-utils/Cargo.toml
+++ b/actix-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-utils"
-version = "3.0.0"
+version = "2.0.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Various network related services and utilities for the Actix ecosystem."
 keywords = ["network", "framework", "async", "futures"]

--- a/actix-utils/src/timeout.rs
+++ b/actix-utils/src/timeout.rs
@@ -165,21 +165,21 @@ where
 pin_project! {
     /// `TimeoutService` response future
     #[derive(Debug)]
-    pub struct TimeoutServiceResponse<T, Req>
+    pub struct TimeoutServiceResponse<S, Req>
     where
-        T: Service<Req>
+        S: Service<Req>
     {
         #[pin]
-        fut: T::Future,
+        fut: S::Future,
         sleep: Delay,
     }
 }
 
-impl<T, Req> Future for TimeoutServiceResponse<T, Req>
+impl<S, Req> Future for TimeoutServiceResponse<S, Req>
 where
-    T: Service<Req>,
+    S: Service<Req>,
 {
-    type Output = Result<T::Response, TimeoutError<T::Error>>;
+    type Output = Result<S::Response, TimeoutError<S::Error>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/actix-utils/src/timeout.rs
+++ b/actix-utils/src/timeout.rs
@@ -2,6 +2,7 @@
 //!
 //! If the response does not complete within the specified timeout, the response
 //! will be aborted.
+
 use core::future::Future;
 use core::marker::PhantomData;
 use core::pin::Pin;
@@ -10,6 +11,7 @@ use core::{fmt, time};
 
 use actix_rt::time::{delay_for, Delay};
 use actix_service::{IntoService, Service, Transform};
+use pin_project_lite::pin_project;
 
 /// Applies a timeout to requests.
 #[derive(Debug)]
@@ -77,21 +79,21 @@ impl<E> Clone for Timeout<E> {
     }
 }
 
-impl<S, E> Transform<S> for Timeout<E>
+impl<S, E, Req> Transform<S, Req> for Timeout<E>
 where
-    S: Service,
+    S: Service<Req>,
 {
-    type Request = S::Request;
     type Response = S::Response;
     type Error = TimeoutError<S::Error>;
-    type Transform = TimeoutService<S>;
     type InitError = E;
+    type Transform = TimeoutService<S, Req>;
     type Future = TimeoutFuture<Self::Transform, Self::InitError>;
 
     fn new_transform(&self, service: S) -> Self::Future {
         let service = TimeoutService {
             service,
             timeout: self.timeout,
+            _phantom: PhantomData,
         };
 
         TimeoutFuture {
@@ -118,40 +120,41 @@ impl<T, E> Future for TimeoutFuture<T, E> {
 
 /// Applies a timeout to requests.
 #[derive(Debug, Clone)]
-pub struct TimeoutService<S> {
+pub struct TimeoutService<S, Req> {
     service: S,
     timeout: time::Duration,
+    _phantom: PhantomData<Req>,
 }
 
-impl<S> TimeoutService<S>
+impl<S, Req> TimeoutService<S, Req>
 where
-    S: Service,
+    S: Service<Req>,
 {
     pub fn new<U>(timeout: time::Duration, service: U) -> Self
     where
-        U: IntoService<S>,
+        U: IntoService<S, Req>,
     {
         TimeoutService {
             timeout,
             service: service.into_service(),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<S> Service for TimeoutService<S>
+impl<S, Req> Service<Req> for TimeoutService<S, Req>
 where
-    S: Service,
+    S: Service<Req>,
 {
-    type Request = S::Request;
     type Response = S::Response;
     type Error = TimeoutError<S::Error>;
-    type Future = TimeoutServiceResponse<S>;
+    type Future = TimeoutServiceResponse<S, Req>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.service.poll_ready(cx).map_err(TimeoutError::Service)
     }
 
-    fn call(&mut self, request: S::Request) -> Self::Future {
+    fn call(&mut self, request: Req) -> Self::Future {
         TimeoutServiceResponse {
             fut: self.service.call(request),
             sleep: delay_for(self.timeout),
@@ -159,19 +162,22 @@ where
     }
 }
 
-pin_project_lite::pin_project! {
+pin_project! {
     /// `TimeoutService` response future
     #[derive(Debug)]
-    pub struct TimeoutServiceResponse<T: Service> {
+    pub struct TimeoutServiceResponse<T, Req>
+    where
+        T: Service<Req>
+    {
         #[pin]
         fut: T::Future,
         sleep: Delay,
     }
 }
 
-impl<T> Future for TimeoutServiceResponse<T>
+impl<T, Req> Future for TimeoutServiceResponse<T, Req>
 where
-    T: Service,
+    T: Service<Req>,
 {
     type Output = Result<T::Response, TimeoutError<T::Error>>;
 
@@ -204,8 +210,7 @@ mod tests {
 
     struct SleepService(Duration);
 
-    impl Service for SleepService {
-        type Request = ();
+    impl Service<()> for SleepService {
         type Response = ();
         type Error = ();
         type Future = LocalBoxFuture<'static, Result<(), ()>>;


### PR DESCRIPTION
## PR Type
Improvement


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
It's advantageous to accept multiple request types for a given service. I believe this will simplify some of the complex types and handling in actix-web http1/http2 request dispatching.

Obviously massive breaking change to actix-service. Other breaking changes include:

actix-connect:
- new_connector()
- new_connector_factory()
- default_connector()
- default_connector_factory()

actix-server:
- ServiceFactory
- ServiceRuntime::service()

