### PR TITLE
remove futures-util from service deps

### DIFF
--- a/actix-service/CHANGES.md
+++ b/actix-service/CHANGES.md
@@ -8,9 +8,11 @@
 * Migrate pin projections to `pin-project-lite`. [#233]
 * Remove `AndThenApplyFn` and Pipeline `and_then_apply_fn`. Use the
   `.and_then(apply_fn(...))` construction. [#233]
+* Move non-vital methods to `ServiceExt` and `ServiceFactoryExt` extension traits. [#235]
 
 [#232]: https://github.com/actix/actix-net/pull/232
 [#233]: https://github.com/actix/actix-net/pull/233
+[#235]: https://github.com/actix/actix-net/pull/235
 
 
 ## 1.0.6 - 2020-08-09

--- a/actix-service/Cargo.toml
+++ b/actix-service/Cargo.toml
@@ -17,10 +17,9 @@ name = "actix_service"
 path = "src/lib.rs"
 
 [dependencies]
-pin-project-lite = "0.2"
-futures-util = { version = "0.3.7", default-features = false }
 futures-core = { version = "0.3.7", default-features = false }
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 actix-rt = "1.0.0"
-criterion = "0.3"
+futures-util = { version = "0.3.7", default-features = false }

--- a/actix-service/src/and_then.rs
+++ b/actix-service/src/and_then.rs
@@ -279,9 +279,11 @@ mod tests {
         task::{Context, Poll},
     };
 
-    use futures_util::future::{lazy, ok, ready, Ready};
+    use futures_util::future::lazy;
 
-    use crate::{fn_factory, pipeline, pipeline_factory, Service, ServiceFactory};
+    use crate::{
+        fn_factory, ok, pipeline, pipeline_factory, ready, Ready, Service, ServiceFactory,
+    };
 
     struct Srv1(Rc<Cell<usize>>);
 

--- a/actix-service/src/apply.rs
+++ b/actix-service/src/apply.rs
@@ -211,10 +211,10 @@ where
 mod tests {
     use core::task::Poll;
 
-    use futures_util::future::{lazy, ok, Ready};
+    use futures_util::future::lazy;
 
     use super::*;
-    use crate::{pipeline, pipeline_factory, Service, ServiceFactory};
+    use crate::{ok, pipeline, pipeline_factory, Ready, Service, ServiceFactory};
 
     #[derive(Clone)]
     struct Srv;

--- a/actix-service/src/boxed.rs
+++ b/actix-service/src/boxed.rs
@@ -6,8 +6,6 @@ use core::{
     task::{Context, Poll},
 };
 
-use futures_util::future::FutureExt;
-
 use crate::{Service, ServiceFactory};
 
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
@@ -103,11 +101,11 @@ where
     type Future = BoxFuture<Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, cfg: Cfg) -> Self::Future {
-        Box::pin(
-            self.factory
-                .new_service(cfg)
-                .map(|res| res.map(ServiceWrapper::boxed)),
-        )
+        let fut = self.factory.new_service(cfg);
+        Box::pin(async {
+            let res = fut.await;
+            res.map(ServiceWrapper::boxed)
+        })
     }
 }
 

--- a/actix-service/src/ext.rs
+++ b/actix-service/src/ext.rs
@@ -1,0 +1,70 @@
+use crate::{dev, Service, ServiceFactory};
+
+pub trait ServiceExt<Req>: Service<Req> {
+    /// Map this service's output to a different type, returning a new service
+    /// of the resulting type.
+    ///
+    /// This function is similar to the `Option::map` or `Iterator::map` where
+    /// it will change the type of the underlying service.
+    ///
+    /// Note that this function consumes the receiving service and returns a
+    /// wrapped version of it, similar to the existing `map` methods in the
+    /// standard library.
+    fn map<F, R>(self, f: F) -> dev::Map<Self, F, Req, R>
+    where
+        Self: Sized,
+        F: FnMut(Self::Response) -> R,
+    {
+        dev::Map::new(self, f)
+    }
+
+    /// Map this service's error to a different error, returning a new service.
+    ///
+    /// This function is similar to the `Result::map_err` where it will change
+    /// the error type of the underlying service. For example, this can be useful to
+    /// ensure that services have the same error type.
+    ///
+    /// Note that this function consumes the receiving service and returns a
+    /// wrapped version of it.
+    fn map_err<F, E>(self, f: F) -> dev::MapErr<Self, Req, F, E>
+    where
+        Self: Sized,
+        F: Fn(Self::Error) -> E,
+    {
+        dev::MapErr::new(self, f)
+    }
+}
+
+impl<S, Req> ServiceExt<Req> for S where S: Service<Req> {}
+
+pub trait ServiceFactoryExt<Req>: ServiceFactory<Req> {
+    /// Map this service's output to a different type, returning a new service
+    /// of the resulting type.
+    fn map<F, R>(self, f: F) -> crate::map::MapServiceFactory<Self, F, Req, R>
+    where
+        Self: Sized,
+        F: FnMut(Self::Response) -> R + Clone,
+    {
+        crate::map::MapServiceFactory::new(self, f)
+    }
+
+    /// Map this service's error to a different error, returning a new service.
+    fn map_err<F, E>(self, f: F) -> crate::map_err::MapErrServiceFactory<Self, Req, F, E>
+    where
+        Self: Sized,
+        F: Fn(Self::Error) -> E + Clone,
+    {
+        crate::map_err::MapErrServiceFactory::new(self, f)
+    }
+
+    /// Map this factory's init error to a different error, returning a new service.
+    fn map_init_err<F, E>(self, f: F) -> crate::map_init_err::MapInitErr<Self, F, Req, E>
+    where
+        Self: Sized,
+        F: Fn(Self::InitError) -> E + Clone,
+    {
+        crate::map_init_err::MapInitErr::new(self, f)
+    }
+}
+
+impl<S, Req> ServiceFactoryExt<Req> for S where S: ServiceFactory<Req> {}

--- a/actix-service/src/fn_service.rs
+++ b/actix-service/src/fn_service.rs
@@ -1,8 +1,6 @@
 use core::{future::Future, marker::PhantomData, task::Poll};
 
-use futures_util::future::{ok, Ready};
-
-use crate::{IntoService, IntoServiceFactory, Service, ServiceFactory};
+use crate::{ok, IntoService, IntoServiceFactory, Ready, Service, ServiceFactory};
 
 /// Create `ServiceFactory` for function that can act as a `Service`
 pub fn fn_service<F, Fut, Req, Res, Err, Cfg>(
@@ -357,10 +355,10 @@ where
 mod tests {
     use core::task::Poll;
 
-    use futures_util::future::{lazy, ok};
+    use futures_util::future::lazy;
 
     use super::*;
-    use crate::{Service, ServiceFactory};
+    use crate::{ok, Service, ServiceFactory};
 
     #[actix_rt::test]
     async fn test_fn_service() {

--- a/actix-service/src/map.rs
+++ b/actix-service/src/map.rs
@@ -199,10 +199,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures_util::future::{lazy, ok, Ready};
+    use futures_util::future::lazy;
 
     use super::*;
-    use crate::{IntoServiceFactory, Service, ServiceFactory};
+    use crate::{
+        ok, IntoServiceFactory, Ready, Service, ServiceExt, ServiceFactory, ServiceFactoryExt,
+    };
 
     struct Srv;
 

--- a/actix-service/src/map_err.rs
+++ b/actix-service/src/map_err.rs
@@ -203,10 +203,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use futures_util::future::{err, lazy, ok, Ready};
+    use futures_util::future::lazy;
 
     use super::*;
-    use crate::{IntoServiceFactory, Service, ServiceFactory};
+    use crate::{
+        err, ok, IntoServiceFactory, Ready, Service, ServiceExt, ServiceFactory,
+        ServiceFactoryExt,
+    };
 
     struct Srv;
 

--- a/actix-service/src/ready.rs
+++ b/actix-service/src/ready.rs
@@ -1,0 +1,54 @@
+//! When MSRV is 1.48, replace with `core::future::Ready` and `core::future::ready()`.
+
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Future for the [`ready`](ready()) function.
+#[derive(Debug, Clone)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Ready<T> {
+    val: Option<T>,
+}
+
+impl<T> Ready<T> {
+    /// Unwraps the value from this immediately ready future.
+    #[inline]
+    pub fn into_inner(mut self) -> T {
+        self.val.take().unwrap()
+    }
+}
+
+impl<T> Unpin for Ready<T> {}
+
+impl<T> Future for Ready<T> {
+    type Output = T;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<T> {
+        let val = self.val.take().expect("Ready can not be polled twice.");
+        Poll::Ready(val)
+    }
+}
+
+/// Creates a future that is immediately ready with a value.
+#[allow(dead_code)]
+pub(crate) fn ready<T>(val: T) -> Ready<T> {
+    Ready { val: Some(val) }
+}
+
+/// Create a future that is immediately ready with a success value.
+#[allow(dead_code)]
+pub(crate) fn ok<T, E>(val: T) -> Ready<Result<T, E>> {
+    Ready { val: Some(Ok(val)) }
+}
+
+/// Create a future that is immediately ready with an error value.
+#[allow(dead_code)]
+pub(crate) fn err<T, E>(err: E) -> Ready<Result<T, E>> {
+    Ready {
+        val: Some(Err(err)),
+    }
+}

--- a/actix-service/src/then.rs
+++ b/actix-service/src/then.rs
@@ -254,9 +254,9 @@ mod tests {
         task::{Context, Poll},
     };
 
-    use futures_util::future::{err, lazy, ok, ready, Ready};
+    use futures_util::future::lazy;
 
-    use crate::{pipeline, pipeline_factory, Service, ServiceFactory};
+    use crate::{err, ok, pipeline, pipeline_factory, ready, Ready, Service, ServiceFactory};
 
     #[derive(Clone)]
     struct Srv1(Rc<Cell<usize>>);


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
- Move map methods to *Ext extension traits.
- Remove futures-util from main deps by providing home basic future::Ready replacement.