### PR TITLE
change default name resolver and allow custom resolvers

### DIFF
--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -9,9 +9,6 @@ use std::{fmt, thread};
 
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::{channel, error::RecvError as Canceled, Sender};
-// use futures_util::stream::FuturesUnordered;
-// use tokio::task::JoinHandle;
-// use tokio::stream::StreamExt;
 use tokio::task::LocalSet;
 
 use crate::runtime::Runtime;
@@ -19,12 +16,6 @@ use crate::system::System;
 
 thread_local!(
     static ADDR: RefCell<Option<Arbiter>> = RefCell::new(None);
-    // TODO: Commented out code are for Arbiter::local_join function.
-    // It can be safely removed if this function is not used in actix-*.
-    //
-    // /// stores join handle for spawned async tasks.
-    // static HANDLE: RefCell<FuturesUnordered<JoinHandle<()>>> =
-    //     RefCell::new(FuturesUnordered::new());
     static STORAGE: RefCell<HashMap<TypeId, Box<dyn Any>>> = RefCell::new(HashMap::new());
 );
 
@@ -154,11 +145,6 @@ impl Arbiter {
     where
         F: Future<Output = ()> + 'static,
     {
-        // HANDLE.with(|handle| {
-        //     let handle = handle.borrow();
-        //     handle.push(tokio::task::spawn_local(future));
-        // });
-        // let _ = tokio::task::spawn_local(CleanupPending);
         let _ = tokio::task::spawn_local(future);
     }
 
@@ -277,31 +263,11 @@ impl Arbiter {
 
     /// Returns a future that will be completed once all currently spawned futures
     /// have completed.
-    #[deprecated(since = "1.2.0", note = "Arbiter::local_join function is removed.")]
+    #[deprecated(since = "2.0.0", note = "Arbiter::local_join function is removed.")]
     pub async fn local_join() {
-        // let handle = HANDLE.with(|fut| std::mem::take(&mut *fut.borrow_mut()));
-        // async move {
-        //     handle.collect::<Vec<_>>().await;
-        // }
         unimplemented!("Arbiter::local_join function is removed.")
     }
 }
-
-// /// Future used for cleaning-up already finished `JoinHandle`s
-// /// from the `PENDING` list so the vector doesn't grow indefinitely
-// struct CleanupPending;
-//
-// impl Future for CleanupPending {
-//     type Output = ();
-//
-//     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-//         HANDLE.with(move |handle| {
-//             recycle_join_handle(&mut *handle.borrow_mut(), cx);
-//         });
-//
-//         Poll::Ready(())
-//     }
-// }
 
 struct ArbiterController {
     rx: UnboundedReceiver<ArbiterCommand>,
@@ -330,11 +296,6 @@ impl Future for ArbiterController {
                 Poll::Ready(Some(item)) => match item {
                     ArbiterCommand::Stop => return Poll::Ready(()),
                     ArbiterCommand::Execute(fut) => {
-                        // HANDLE.with(|handle| {
-                        //     let mut handle = handle.borrow_mut();
-                        //     handle.push(tokio::task::spawn_local(fut));
-                        //     recycle_join_handle(&mut *handle, cx);
-                        // });
                         tokio::task::spawn_local(fut);
                     }
                     ArbiterCommand::ExecuteFn(f) => {
@@ -346,20 +307,6 @@ impl Future for ArbiterController {
         }
     }
 }
-
-// fn recycle_join_handle(handle: &mut FuturesUnordered<JoinHandle<()>>, cx: &mut Context<'_>) {
-//     let _ = Pin::new(&mut *handle).poll_next(cx);
-//
-//     // Try to recycle more join handles and free up memory.
-//     //
-//     // this is a guess. The yield limit for FuturesUnordered is 32.
-//     // So poll an extra 3 times would make the total poll below 128.
-//     if handle.len() > 64 {
-//         (0..3).for_each(|_| {
-//             let _ = Pin::new(&mut *handle).poll_next(cx);
-//         })
-//     }
-// }
 
 #[derive(Debug)]
 pub(crate) enum SystemCommand {

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -66,7 +66,7 @@ pub mod time {
     pub use tokio::time::{timeout, Timeout};
 }
 
-/// Blocking task management.
+/// Task management.
 pub mod task {
     pub use tokio::task::{spawn_blocking, yield_now, JoinHandle};
 }

--- a/actix-rt/tests/integration_tests.rs
+++ b/actix-rt/tests/integration_tests.rs
@@ -62,43 +62,6 @@ fn join_another_arbiter() {
     );
 }
 
-// #[test]
-// fn join_current_arbiter() {
-//     let time = Duration::from_secs(2);
-//
-//     let instant = Instant::now();
-//     actix_rt::System::new("test_join_current_arbiter").block_on(async move {
-//         actix_rt::spawn(async move {
-//             tokio::time::delay_for(time).await;
-//             actix_rt::Arbiter::current().stop();
-//         });
-//         actix_rt::Arbiter::local_join().await;
-//     });
-//     assert!(
-//         instant.elapsed() >= time,
-//         "Join on current arbiter should wait for all spawned futures"
-//     );
-//
-//     let large_timer = Duration::from_secs(20);
-//     let instant = Instant::now();
-//     actix_rt::System::new("test_join_current_arbiter").block_on(async move {
-//         actix_rt::spawn(async move {
-//             tokio::time::delay_for(time).await;
-//             actix_rt::Arbiter::current().stop();
-//         });
-//         let f = actix_rt::Arbiter::local_join();
-//         actix_rt::spawn(async move {
-//             tokio::time::delay_for(large_timer).await;
-//             actix_rt::Arbiter::current().stop();
-//         });
-//         f.await;
-//     });
-//     assert!(
-//         instant.elapsed() < large_timer,
-//         "local_join should await only for the already spawned futures"
-//     );
-// }
-
 #[test]
 fn non_static_block_on() {
     let string = String::from("test_str");

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -28,7 +28,7 @@ actix-rt = { version = "2.0.0-beta.2", default-features = false }
 actix-service = "2.0.0-beta.3"
 actix-utils = "3.0.0-beta.1"
 
-futures-core = { version = "0.3.7", default-features = false }
+futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
 log = "0.4"
 mio = { version = "0.7.6", features = ["os-poll", "net"] }
 num_cpus = "1.13"

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 
 [dependencies]
 actix-codec = "0.4.0-beta.1"
-actix-rt = "2.0.0-beta.2"
+actix-rt = { version = "2.0.0-beta.2", default-features = false }
 actix-service = "2.0.0-beta.3"
 actix-utils = "3.0.0-beta.1"
 

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -2,9 +2,13 @@
 
 ## Unreleased - 2021-xx-xx
 * Remove `trust-dns-proto` and `trust-dns-resolver` [#248]
-* Use `tokio::net::lookup_host` for as simple and basic default resolver [#248]
-* Add `Resolve` trait for custom dns resolver. Add `Resolver::new_custom` function
-  to construct custom resolvers.[#248]
+* Use `tokio::net::lookup_host` as simple and basic default resolver [#248]
+* Add `Resolve` trait for custom dns resolver. [#248]
+* Add `Resolver::new_custom` function to construct custom resolvers. [#248]
+* Export `webpki_roots::TLS_SERVER_ROOTS` in `actix_tls::connect` mod and remove
+  the export from `actix_tls::accept` [#248]
+* Remove `ConnectTakeAddrsIter`. `Connect::take_addrs` would return 
+  `ConnectAddrsIter<'static>` as owned iterator. [#248]
 
 [#248]: https://github.com/actix/actix-net/pull/248
 

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -1,6 +1,12 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Remove `trust-dns-proto` and `trust-dns-resolver` [#248]
+* Use `tokio::net::lookup_host` for as simple and basic default resolver [#248]
+* Add `Resolve` trait for custom dns resolver. Add `Resolver::new_custom` function
+  to construct custom resolvers.[#248]
+
+[#248]: https://github.com/actix/actix-net/pull/248
 
 
 ## 3.0.0-beta.2 - 2021-xx-xx

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -80,3 +80,4 @@ bytes = "1"
 env_logger = "0.8"
 futures-util = { version = "0.3.7", default-features = false, features = ["sink"] }
 log = "0.4"
+trust-dns-resolver = "0.20.0"

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -29,7 +29,7 @@ default = ["accept", "connect", "uri"]
 accept = []
 
 # enable connector services
-connect = ["tokio/net"]
+connect = []
 
 # use openssl impls
 openssl = ["tls-openssl", "tokio-openssl"]
@@ -53,7 +53,6 @@ derive_more = "0.99.5"
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
 http = { version = "0.2.3", optional = true }
 log = "0.4"
-tokio = { version = "1", optional = true }
 
 # openssl
 tls-openssl = { package = "openssl", version = "0.10", optional = true }

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -29,7 +29,7 @@ default = ["accept", "connect", "uri"]
 accept = []
 
 # enable connector services
-connect = ["trust-dns-proto/tokio-runtime", "trust-dns-resolver/tokio-runtime", "trust-dns-resolver/system-config"]
+connect = ["tokio/net"]
 
 # use openssl impls
 openssl = ["tls-openssl", "tokio-openssl"]
@@ -45,19 +45,17 @@ uri = ["http"]
 
 [dependencies]
 actix-codec = "0.4.0-beta.1"
-actix-rt = "2.0.0-beta.2"
+actix-rt = { version = "2.0.0-beta.2", default-features = false }
 actix-service = "2.0.0-beta.3"
 actix-utils = "3.0.0-beta.1"
 
 derive_more = "0.99.5"
 either = "1.6"
+futures-core = { version = "0.3.7", default-features = false }
 futures-util = { version = "0.3.7", default-features = false }
-http = { version = "0.2.2", optional = true }
+http = { version = "0.2.3", optional = true }
 log = "0.4"
-
-# resolver
-trust-dns-proto = { version = "0.20.0", default-features = false, optional = true }
-trust-dns-resolver = { version = "0.20.0", default-features = false, optional = true }
+tokio = { version = "1", optional = true }
 
 # openssl
 tls-openssl = { package = "openssl", version = "0.10", optional = true }
@@ -76,6 +74,7 @@ tls-native-tls = { package = "native-tls", version = "0.2", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 
 [dev-dependencies]
+actix-rt = "2.0.0-beta.2"
 actix-server = "2.0.0-beta.2"
 bytes = "1"
 env_logger = "0.8"

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -50,9 +50,7 @@ actix-service = "2.0.0-beta.3"
 actix-utils = "3.0.0-beta.1"
 
 derive_more = "0.99.5"
-either = "1.6"
-futures-core = { version = "0.3.7", default-features = false }
-futures-util = { version = "0.3.7", default-features = false }
+futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
 http = { version = "0.2.3", optional = true }
 log = "0.4"
 tokio = { version = "1", optional = true }

--- a/actix-tls/src/accept/openssl.rs
+++ b/actix-tls/src/accept/openssl.rs
@@ -1,6 +1,8 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use actix_codec::{AsyncRead, AsyncWrite};
 use actix_service::{Service, ServiceFactory};

--- a/actix-tls/src/accept/openssl.rs
+++ b/actix-tls/src/accept/openssl.rs
@@ -5,10 +5,7 @@ use std::task::{Context, Poll};
 use actix_codec::{AsyncRead, AsyncWrite};
 use actix_service::{Service, ServiceFactory};
 use actix_utils::counter::{Counter, CounterGuard};
-use futures_util::{
-    future::{ready, Ready},
-    ready,
-};
+use futures_core::{future::LocalBoxFuture, ready};
 
 pub use openssl::ssl::{
     AlpnError, Error as SslError, HandshakeError, Ssl, SslAcceptor, SslAcceptorBuilder,
@@ -50,15 +47,16 @@ where
     type Config = ();
     type Service = AcceptorService;
     type InitError = ();
-    type Future = Ready<Result<Self::Service, Self::InitError>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, _: ()) -> Self::Future {
-        MAX_CONN_COUNTER.with(|conns| {
-            ready(Ok(AcceptorService {
+        let res = MAX_CONN_COUNTER.with(|conns| {
+            Ok(AcceptorService {
                 acceptor: self.acceptor.clone(),
                 conns: conns.clone(),
-            }))
-        })
+            })
+        });
+        Box::pin(async { res })
     }
 }
 

--- a/actix-tls/src/accept/rustls.rs
+++ b/actix-tls/src/accept/rustls.rs
@@ -1,13 +1,15 @@
-use std::future::Future;
-use std::io;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use actix_codec::{AsyncRead, AsyncWrite};
 use actix_service::{Service, ServiceFactory};
 use actix_utils::counter::{Counter, CounterGuard};
-use futures_util::future::{ready, Ready};
+use futures_core::future::LocalBoxFuture;
 use tokio_rustls::{Accept, TlsAcceptor};
 
 pub use rustls::{ServerConfig, Session};
@@ -52,15 +54,16 @@ where
 
     type Service = AcceptorService;
     type InitError = ();
-    type Future = Ready<Result<Self::Service, Self::InitError>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, _: ()) -> Self::Future {
-        MAX_CONN_COUNTER.with(|conns| {
-            ready(Ok(AcceptorService {
+        let res = MAX_CONN_COUNTER.with(|conns| {
+            Ok(AcceptorService {
                 acceptor: self.config.clone().into(),
                 conns: conns.clone(),
-            }))
-        })
+            })
+        });
+        Box::pin(async { res })
     }
 }
 

--- a/actix-tls/src/accept/rustls.rs
+++ b/actix-tls/src/accept/rustls.rs
@@ -14,7 +14,6 @@ use tokio_rustls::{Accept, TlsAcceptor};
 
 pub use rustls::{ServerConfig, Session};
 pub use tokio_rustls::server::TlsStream;
-pub use webpki_roots::TLS_SERVER_ROOTS;
 
 use super::MAX_CONN_COUNTER;
 

--- a/actix-tls/src/connect/connector.rs
+++ b/actix-tls/src/connect/connector.rs
@@ -1,76 +1,48 @@
 use std::collections::VecDeque;
 use std::future::Future;
 use std::io;
-use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use actix_rt::net::TcpStream;
 use actix_service::{Service, ServiceFactory};
-use futures_util::future::{ready, Ready};
+use futures_core::future::LocalBoxFuture;
 use log::{error, trace};
 
 use super::connect::{Address, Connect, Connection};
 use super::error::ConnectError;
 
 /// TCP connector service factory
-#[derive(Debug)]
-pub struct TcpConnectorFactory<T>(PhantomData<T>);
+#[derive(Copy, Clone, Debug)]
+pub struct TcpConnectorFactory;
 
-impl<T> TcpConnectorFactory<T> {
-    pub fn new() -> Self {
-        TcpConnectorFactory(PhantomData)
-    }
-
+impl TcpConnectorFactory {
     /// Create TCP connector service
-    pub fn service(&self) -> TcpConnector<T> {
-        TcpConnector(PhantomData)
+    pub fn service(&self) -> TcpConnector {
+        TcpConnector
     }
 }
 
-impl<T> Default for TcpConnectorFactory<T> {
-    fn default() -> Self {
-        TcpConnectorFactory(PhantomData)
-    }
-}
-
-impl<T> Clone for TcpConnectorFactory<T> {
-    fn clone(&self) -> Self {
-        TcpConnectorFactory(PhantomData)
-    }
-}
-
-impl<T: Address> ServiceFactory<Connect<T>> for TcpConnectorFactory<T> {
+impl<T: Address> ServiceFactory<Connect<T>> for TcpConnectorFactory {
     type Response = Connection<T, TcpStream>;
     type Error = ConnectError;
     type Config = ();
-    type Service = TcpConnector<T>;
+    type Service = TcpConnector;
     type InitError = ();
-    type Future = Ready<Result<Self::Service, Self::InitError>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, _: ()) -> Self::Future {
-        ready(Ok(self.service()))
+        let service = self.service();
+        Box::pin(async move { Ok(service) })
     }
 }
 
 /// TCP connector service
-#[derive(Default, Debug)]
-pub struct TcpConnector<T>(PhantomData<T>);
+#[derive(Copy, Clone, Debug)]
+pub struct TcpConnector;
 
-impl<T> TcpConnector<T> {
-    pub fn new() -> Self {
-        TcpConnector(PhantomData)
-    }
-}
-
-impl<T> Clone for TcpConnector<T> {
-    fn clone(&self) -> Self {
-        TcpConnector(PhantomData)
-    }
-}
-
-impl<T: Address> Service<Connect<T>> for TcpConnector<T> {
+impl<T: Address> Service<Connect<T>> for TcpConnector {
     type Response = Connection<T, TcpStream>;
     type Error = ConnectError;
     type Future = TcpConnectorResponse<T>;
@@ -89,8 +61,6 @@ impl<T: Address> Service<Connect<T>> for TcpConnector<T> {
         }
     }
 }
-
-type LocalBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 #[doc(hidden)]
 /// TCP stream connector response future
@@ -165,7 +135,7 @@ impl<T: Address> Future for TcpConnectorResponse<T> {
                                 port,
                             );
                             if addrs.is_none() || addrs.as_ref().unwrap().is_empty() {
-                                return Poll::Ready(Err(err.into()));
+                                return Poll::Ready(Err(ConnectError::Io(err)));
                             }
                         }
                     }

--- a/actix-tls/src/connect/error.rs
+++ b/actix-tls/src/connect/error.rs
@@ -1,13 +1,12 @@
 use std::io;
 
-use derive_more::{Display, From};
-use trust_dns_resolver::error::ResolveError;
+use derive_more::Display;
 
-#[derive(Debug, From, Display)]
+#[derive(Debug, Display)]
 pub enum ConnectError {
     /// Failed to resolve the hostname
     #[display(fmt = "Failed resolving hostname: {}", _0)]
-    Resolver(ResolveError),
+    Resolver(Box<dyn std::error::Error>),
 
     /// No dns records
     #[display(fmt = "No dns records found for the input")]

--- a/actix-tls/src/connect/mod.rs
+++ b/actix-tls/src/connect/mod.rs
@@ -14,67 +14,26 @@ pub mod ssl;
 #[cfg(feature = "uri")]
 mod uri;
 
-use actix_rt::{net::TcpStream, Arbiter};
+use actix_rt::net::TcpStream;
 use actix_service::{pipeline, pipeline_factory, Service, ServiceFactory};
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::system_conf::read_system_conf;
-use trust_dns_resolver::TokioAsyncResolver as AsyncResolver;
-
-pub mod resolver {
-    pub use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-    pub use trust_dns_resolver::system_conf::read_system_conf;
-    pub use trust_dns_resolver::{error::ResolveError, AsyncResolver};
-}
 
 pub use self::connect::{Address, Connect, Connection};
 pub use self::connector::{TcpConnector, TcpConnectorFactory};
 pub use self::error::ConnectError;
-pub use self::resolve::{Resolver, ResolverFactory};
+pub use self::resolve::{Resolve, Resolver, ResolverFactory};
 pub use self::service::{ConnectService, ConnectServiceFactory, TcpConnectService};
-
-pub async fn start_resolver(
-    cfg: ResolverConfig,
-    opts: ResolverOpts,
-) -> Result<AsyncResolver, ConnectError> {
-    Ok(AsyncResolver::tokio(cfg, opts)?)
-}
-
-struct DefaultResolver(AsyncResolver);
-
-pub(crate) async fn get_default_resolver() -> Result<AsyncResolver, ConnectError> {
-    if Arbiter::contains_item::<DefaultResolver>() {
-        Ok(Arbiter::get_item(|item: &DefaultResolver| item.0.clone()))
-    } else {
-        let (cfg, opts) = match read_system_conf() {
-            Ok((cfg, opts)) => (cfg, opts),
-            Err(e) => {
-                log::error!("TRust-DNS can not load system config: {}", e);
-                (ResolverConfig::default(), ResolverOpts::default())
-            }
-        };
-
-        let resolver = AsyncResolver::tokio(cfg, opts)?;
-
-        Arbiter::set_item(DefaultResolver(resolver.clone()));
-        Ok(resolver)
-    }
-}
-
-pub async fn start_default_resolver() -> Result<AsyncResolver, ConnectError> {
-    get_default_resolver().await
-}
 
 /// Create TCP connector service.
 pub fn new_connector<T: Address + 'static>(
-    resolver: AsyncResolver,
+    resolver: Resolver,
 ) -> impl Service<Connect<T>, Response = Connection<T, TcpStream>, Error = ConnectError> + Clone
 {
-    pipeline(Resolver::new(resolver)).and_then(TcpConnector::new())
+    pipeline(resolver).and_then(TcpConnector)
 }
 
 /// Create TCP connector service factory.
 pub fn new_connector_factory<T: Address + 'static>(
-    resolver: AsyncResolver,
+    resolver: Resolver,
 ) -> impl ServiceFactory<
     Connect<T>,
     Config = (),
@@ -82,14 +41,14 @@ pub fn new_connector_factory<T: Address + 'static>(
     Error = ConnectError,
     InitError = (),
 > + Clone {
-    pipeline_factory(ResolverFactory::new(resolver)).and_then(TcpConnectorFactory::new())
+    pipeline_factory(ResolverFactory::new(resolver)).and_then(TcpConnectorFactory)
 }
 
 /// Create connector service with default parameters.
 pub fn default_connector<T: Address + 'static>(
 ) -> impl Service<Connect<T>, Response = Connection<T, TcpStream>, Error = ConnectError> + Clone
 {
-    pipeline(Resolver::default()).and_then(TcpConnector::new())
+    new_connector(Resolver::Default)
 }
 
 /// Create connector service factory with default parameters.
@@ -100,5 +59,5 @@ pub fn default_connector_factory<T: Address + 'static>() -> impl ServiceFactory<
     Error = ConnectError,
     InitError = (),
 > + Clone {
-    pipeline_factory(ResolverFactory::default()).and_then(TcpConnectorFactory::new())
+    new_connector_factory(Resolver::Default)
 }

--- a/actix-tls/src/connect/mod.rs
+++ b/actix-tls/src/connect/mod.rs
@@ -4,6 +4,17 @@
 //!
 //! * `openssl` - enables TLS support via `openssl` crate
 //! * `rustls` - enables TLS support via `rustls` crate
+//!
+//! ## Workflow of connector service:
+//! - resolve [`Address`](self::connect::Address) with given [`Resolver`](self::resolve::Resolver)
+//!   and collect [`SocketAddrs`](std::net::SocketAddr).
+//! - establish Tcp connection and return [`TcpStream`](tokio::net::TcpStream).
+//!
+//! ## Workflow of tls connector services:
+//! - Establish [`TcpStream`](tokio::net::TcpStream) with connector service.
+//! - Wrap around the stream and do connect handshake with remote address.
+//! - Return certain stream type impl [`AsyncRead`](tokio::io::AsyncRead) and
+//!   [`AsyncWrite`](tokio::io::AsyncWrite)
 
 mod connect;
 mod connector;

--- a/actix-tls/src/connect/resolve.rs
+++ b/actix-tls/src/connect/resolve.rs
@@ -1,8 +1,4 @@
-use std::{
-    net::{SocketAddr, ToSocketAddrs},
-    rc::Rc,
-    task::Poll,
-};
+use std::{net::SocketAddr, rc::Rc, task::Poll};
 
 use actix_service::{Service, ServiceFactory};
 use futures_core::future::LocalBoxFuture;
@@ -52,7 +48,7 @@ pub enum Resolver {
 pub trait Resolve {
     fn lookup(
         &self,
-        addrs: Vec<SocketAddr>,
+        addrs: String,
     ) -> LocalBoxFuture<'_, Result<Vec<SocketAddr>, Box<dyn std::error::Error>>>;
 }
 
@@ -81,10 +77,6 @@ impl Resolver {
                 Ok(res.collect())
             }
             Self::Custom(resolver) => {
-                let host = host
-                    .to_socket_addrs()
-                    .map_err(|e| ConnectError::Resolver(Box::new(e)))?
-                    .collect();
                 resolver.lookup(host).await.map_err(ConnectError::Resolver)
             }
         }

--- a/actix-tls/src/connect/service.rs
+++ b/actix-tls/src/connect/service.rs
@@ -1,11 +1,12 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use actix_rt::net::TcpStream;
 use actix_service::{Service, ServiceFactory};
-use either::Either;
-use futures_core::future::LocalBoxFuture;
+use futures_core::{future::LocalBoxFuture, ready};
 
 use super::connect::{Address, Connect, Connection};
 use super::connector::{TcpConnector, TcpConnectorFactory};
@@ -81,36 +82,42 @@ impl<T: Address> Service<Connect<T>> for ConnectService {
 
     fn call(&mut self, req: Connect<T>) -> Self::Future {
         ConnectServiceResponse {
-            state: ConnectState::Resolve(self.resolver.call(req)),
+            fut: ConnectFuture::Resolve(self.resolver.call(req)),
             tcp: self.tcp,
         }
     }
 }
 
-enum ConnectState<T: Address> {
+// helper enum to generic over futures of resolve and connect phase.
+pub(crate) enum ConnectFuture<T: Address> {
     Resolve(<Resolver as Service<Connect<T>>>::Future),
     Connect(<TcpConnector as Service<Connect<T>>>::Future),
 }
 
-impl<T: Address> ConnectState<T> {
-    #[allow(clippy::type_complexity)]
-    fn poll(
+// helper enum to contain the future output of ConnectFuture
+pub(crate) enum ConnectOutput<T: Address> {
+    Resolved(Connect<T>),
+    Connected(Connection<T, TcpStream>),
+}
+
+impl<T: Address> ConnectFuture<T> {
+    fn poll_connect(
         &mut self,
         cx: &mut Context<'_>,
-    ) -> Either<Poll<Result<Connection<T, TcpStream>, ConnectError>>, Connect<T>> {
+    ) -> Poll<Result<ConnectOutput<T>, ConnectError>> {
         match self {
-            ConnectState::Resolve(ref mut fut) => match Pin::new(fut).poll(cx) {
-                Poll::Pending => Either::Left(Poll::Pending),
-                Poll::Ready(Ok(res)) => Either::Right(res),
-                Poll::Ready(Err(err)) => Either::Left(Poll::Ready(Err(err))),
-            },
-            ConnectState::Connect(ref mut fut) => Either::Left(Pin::new(fut).poll(cx)),
+            ConnectFuture::Resolve(ref mut fut) => {
+                Pin::new(fut).poll(cx).map_ok(ConnectOutput::Resolved)
+            }
+            ConnectFuture::Connect(ref mut fut) => {
+                Pin::new(fut).poll(cx).map_ok(ConnectOutput::Connected)
+            }
         }
     }
 }
 
 pub struct ConnectServiceResponse<T: Address> {
-    state: ConnectState<T>,
+    fut: ConnectFuture<T>,
     tcp: TcpConnector,
 }
 
@@ -118,17 +125,13 @@ impl<T: Address> Future for ConnectServiceResponse<T> {
     type Output = Result<Connection<T, TcpStream>, ConnectError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let res = match self.state.poll(cx) {
-            Either::Right(res) => {
-                self.state = ConnectState::Connect(self.tcp.call(res));
-                self.state.poll(cx)
+        loop {
+            match ready!(self.fut.poll_connect(cx))? {
+                ConnectOutput::Resolved(res) => {
+                    self.fut = ConnectFuture::Connect(self.tcp.call(res));
+                }
+                ConnectOutput::Connected(res) => return Poll::Ready(Ok(res)),
             }
-            Either::Left(res) => return res,
-        };
-
-        match res {
-            Either::Left(res) => res,
-            Either::Right(_) => panic!(),
         }
     }
 }
@@ -139,7 +142,7 @@ pub struct TcpConnectService {
     resolver: Resolver,
 }
 
-impl<T: Address + 'static> Service<Connect<T>> for TcpConnectService {
+impl<T: Address> Service<Connect<T>> for TcpConnectService {
     type Response = TcpStream;
     type Error = ConnectError;
     type Future = TcpConnectServiceResponse<T>;
@@ -148,43 +151,14 @@ impl<T: Address + 'static> Service<Connect<T>> for TcpConnectService {
 
     fn call(&mut self, req: Connect<T>) -> Self::Future {
         TcpConnectServiceResponse {
-            state: TcpConnectState::Resolve(self.resolver.call(req)),
+            fut: ConnectFuture::Resolve(self.resolver.call(req)),
             tcp: self.tcp,
         }
     }
 }
 
-enum TcpConnectState<T: Address> {
-    Resolve(<Resolver as Service<Connect<T>>>::Future),
-    Connect(<TcpConnector as Service<Connect<T>>>::Future),
-}
-
-impl<T: Address> TcpConnectState<T> {
-    fn poll(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Either<Poll<Result<TcpStream, ConnectError>>, Connect<T>> {
-        match self {
-            TcpConnectState::Resolve(ref mut fut) => match Pin::new(fut).poll(cx) {
-                Poll::Pending => (),
-                Poll::Ready(Ok(res)) => return Either::Right(res),
-                Poll::Ready(Err(err)) => return Either::Left(Poll::Ready(Err(err))),
-            },
-            TcpConnectState::Connect(ref mut fut) => {
-                if let Poll::Ready(res) = Pin::new(fut).poll(cx) {
-                    return match res {
-                        Ok(conn) => Either::Left(Poll::Ready(Ok(conn.into_parts().0))),
-                        Err(err) => Either::Left(Poll::Ready(Err(err))),
-                    };
-                }
-            }
-        }
-        Either::Left(Poll::Pending)
-    }
-}
-
 pub struct TcpConnectServiceResponse<T: Address> {
-    state: TcpConnectState<T>,
+    fut: ConnectFuture<T>,
     tcp: TcpConnector,
 }
 
@@ -192,17 +166,13 @@ impl<T: Address> Future for TcpConnectServiceResponse<T> {
     type Output = Result<TcpStream, ConnectError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let res = match self.state.poll(cx) {
-            Either::Right(res) => {
-                self.state = TcpConnectState::Connect(self.tcp.call(res));
-                self.state.poll(cx)
+        loop {
+            match ready!(self.fut.poll_connect(cx))? {
+                ConnectOutput::Resolved(res) => {
+                    self.fut = ConnectFuture::Connect(self.tcp.call(res));
+                }
+                ConnectOutput::Connected(conn) => return Poll::Ready(Ok(conn.into_parts().0)),
             }
-            Either::Left(res) => return res,
-        };
-
-        match res {
-            Either::Left(res) => res,
-            Either::Right(_) => panic!(),
         }
     }
 }

--- a/actix-tls/src/connect/ssl/openssl.rs
+++ b/actix-tls/src/connect/ssl/openssl.rs
@@ -31,9 +31,7 @@ impl OpensslConnector {
     pub fn new(connector: SslConnector) -> Self {
         OpensslConnector { connector }
     }
-}
 
-impl OpensslConnector {
     pub fn service(connector: SslConnector) -> OpensslConnectorService {
         OpensslConnectorService { connector }
     }

--- a/actix-tls/src/connect/ssl/openssl.rs
+++ b/actix-tls/src/connect/ssl/openssl.rs
@@ -1,23 +1,25 @@
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::{fmt, io};
+use std::{
+    fmt,
+    future::Future,
+    io,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use actix_codec::{AsyncRead, AsyncWrite};
 use actix_rt::net::TcpStream;
 use actix_service::{Service, ServiceFactory};
-use futures_util::{
-    future::{ready, Either, Ready},
-    ready,
-};
+use futures_core::{future::LocalBoxFuture, ready};
+use futures_util::future::{ready, Either, Ready};
 use log::trace;
+
 pub use openssl::ssl::{Error as SslError, HandshakeError, SslConnector, SslMethod};
 pub use tokio_openssl::SslStream;
-use trust_dns_resolver::TokioAsyncResolver as AsyncResolver;
 
+use crate::connect::resolve::Resolve;
 use crate::connect::{
-    Address, Connect, ConnectError, ConnectService, ConnectServiceFactory, Connection,
+    Address, Connect, ConnectError, ConnectService, ConnectServiceFactory, Connection, Resolver,
 };
 
 /// OpenSSL connector factory
@@ -55,12 +57,11 @@ where
     type Config = ();
     type Service = OpensslConnectorService;
     type InitError = ();
-    type Future = Ready<Result<Self::Service, Self::InitError>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, _: ()) -> Self::Future {
-        ready(Ok(OpensslConnectorService {
-            connector: self.connector.clone(),
-        }))
+        let connector = self.connector.clone();
+        Box::pin(async { Ok(OpensslConnectorService { connector }) })
     }
 }
 
@@ -139,30 +140,30 @@ where
     }
 }
 
-pub struct OpensslConnectServiceFactory<T> {
-    tcp: ConnectServiceFactory<T>,
+pub struct OpensslConnectServiceFactory {
+    tcp: ConnectServiceFactory,
     openssl: OpensslConnector,
 }
 
-impl<T> OpensslConnectServiceFactory<T> {
+impl OpensslConnectServiceFactory {
     /// Construct new OpensslConnectService factory
     pub fn new(connector: SslConnector) -> Self {
         OpensslConnectServiceFactory {
-            tcp: ConnectServiceFactory::default(),
+            tcp: ConnectServiceFactory::new(Resolver::Default),
             openssl: OpensslConnector::new(connector),
         }
     }
 
     /// Construct new connect service with custom DNS resolver
-    pub fn with_resolver(connector: SslConnector, resolver: AsyncResolver) -> Self {
+    pub fn with_resolver(connector: SslConnector, resolver: impl Resolve + 'static) -> Self {
         OpensslConnectServiceFactory {
-            tcp: ConnectServiceFactory::with_resolver(resolver),
+            tcp: ConnectServiceFactory::new(Resolver::new_custom(resolver)),
             openssl: OpensslConnector::new(connector),
         }
     }
 
     /// Construct OpenSSL connect service
-    pub fn service(&self) -> OpensslConnectService<T> {
+    pub fn service(&self) -> OpensslConnectService {
         OpensslConnectService {
             tcp: self.tcp.service(),
             openssl: OpensslConnectorService {
@@ -172,7 +173,7 @@ impl<T> OpensslConnectServiceFactory<T> {
     }
 }
 
-impl<T> Clone for OpensslConnectServiceFactory<T> {
+impl Clone for OpensslConnectServiceFactory {
     fn clone(&self) -> Self {
         OpensslConnectServiceFactory {
             tcp: self.tcp.clone(),
@@ -181,26 +182,27 @@ impl<T> Clone for OpensslConnectServiceFactory<T> {
     }
 }
 
-impl<T: Address + 'static> ServiceFactory<Connect<T>> for OpensslConnectServiceFactory<T> {
+impl<T: Address + 'static> ServiceFactory<Connect<T>> for OpensslConnectServiceFactory {
     type Response = SslStream<TcpStream>;
     type Error = ConnectError;
     type Config = ();
-    type Service = OpensslConnectService<T>;
+    type Service = OpensslConnectService;
     type InitError = ();
-    type Future = Ready<Result<Self::Service, Self::InitError>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, _: ()) -> Self::Future {
-        ready(Ok(self.service()))
+        let service = self.service();
+        Box::pin(async { Ok(service) })
     }
 }
 
 #[derive(Clone)]
-pub struct OpensslConnectService<T> {
-    tcp: ConnectService<T>,
+pub struct OpensslConnectService {
+    tcp: ConnectService,
     openssl: OpensslConnectorService,
 }
 
-impl<T: Address + 'static> Service<Connect<T>> for OpensslConnectService<T> {
+impl<T: Address + 'static> Service<Connect<T>> for OpensslConnectService {
     type Response = SslStream<TcpStream>;
     type Error = ConnectError;
     type Future = OpensslConnectServiceResponse<T>;
@@ -217,7 +219,7 @@ impl<T: Address + 'static> Service<Connect<T>> for OpensslConnectService<T> {
 }
 
 pub struct OpensslConnectServiceResponse<T: Address + 'static> {
-    fut1: Option<<ConnectService<T> as Service<Connect<T>>>::Future>,
+    fut1: Option<<ConnectService as Service<Connect<T>>>::Future>,
     fut2: Option<<OpensslConnectorService as Service<Connection<T, TcpStream>>>::Future>,
     openssl: OpensslConnectorService,
 }

--- a/actix-tls/src/connect/ssl/rustls.rs
+++ b/actix-tls/src/connect/ssl/rustls.rs
@@ -8,6 +8,7 @@ use std::{
 
 pub use rustls::Session;
 pub use tokio_rustls::{client::TlsStream, rustls::ClientConfig};
+pub use webpki_roots::TLS_SERVER_ROOTS;
 
 use actix_codec::{AsyncRead, AsyncWrite};
 use actix_service::{Service, ServiceFactory};

--- a/actix-tls/tests/test_connect.rs
+++ b/actix-tls/tests/test_connect.rs
@@ -7,11 +7,7 @@ use actix_service::{fn_service, Service, ServiceFactory};
 use bytes::Bytes;
 use futures_util::sink::SinkExt;
 
-use actix_tls::connect::{
-    self as actix_connect,
-    resolver::{ResolverConfig, ResolverOpts},
-    Connect,
-};
+use actix_tls::connect::{self as actix_connect, Connect};
 
 #[cfg(all(feature = "connect", feature = "openssl"))]
 #[actix_rt::test]
@@ -57,14 +53,13 @@ async fn test_static_str() {
         })
     });
 
-    let resolver = actix_connect::start_default_resolver().await.unwrap();
-    let mut conn = actix_connect::new_connector(resolver.clone());
+    let mut conn = actix_connect::default_connector();
 
     let con = conn.call(Connect::with("10", srv.addr())).await.unwrap();
     assert_eq!(con.peer_addr().unwrap(), srv.addr());
 
     let connect = Connect::new(srv.host().to_owned());
-    let mut conn = actix_connect::new_connector(resolver);
+    let mut conn = actix_connect::default_connector();
     let con = conn.call(connect).await;
     assert!(con.is_err());
 }
@@ -79,12 +74,7 @@ async fn test_new_service() {
         })
     });
 
-    let resolver =
-        actix_connect::start_resolver(ResolverConfig::default(), ResolverOpts::default())
-            .await
-            .unwrap();
-
-    let factory = actix_connect::new_connector_factory(resolver);
+    let factory = actix_connect::default_connector_factory();
 
     let mut conn = factory.new_service(()).await.unwrap();
     let con = conn.call(Connect::with("10", srv.addr())).await.unwrap();

--- a/actix-tls/tests/test_connect.rs
+++ b/actix-tls/tests/test_connect.rs
@@ -1,13 +1,15 @@
 use std::io;
+use std::net::SocketAddr;
 
 use actix_codec::{BytesCodec, Framed};
 use actix_rt::net::TcpStream;
 use actix_server::TestServer;
 use actix_service::{fn_service, Service, ServiceFactory};
 use bytes::Bytes;
+use futures_core::future::LocalBoxFuture;
 use futures_util::sink::SinkExt;
 
-use actix_tls::connect::{self as actix_connect, Connect};
+use actix_tls::connect::{self as actix_connect, Connect, Resolve, Resolver};
 
 #[cfg(all(feature = "connect", feature = "openssl"))]
 #[actix_rt::test]
@@ -75,6 +77,54 @@ async fn test_new_service() {
     });
 
     let factory = actix_connect::default_connector_factory();
+
+    let mut conn = factory.new_service(()).await.unwrap();
+    let con = conn.call(Connect::with("10", srv.addr())).await.unwrap();
+    assert_eq!(con.peer_addr().unwrap(), srv.addr());
+}
+
+#[actix_rt::test]
+async fn test_custom_resolver() {
+    use trust_dns_resolver::TokioAsyncResolver;
+
+    let srv = TestServer::with(|| {
+        fn_service(|io: TcpStream| async {
+            let mut framed = Framed::new(io, BytesCodec);
+            framed.send(Bytes::from_static(b"test")).await?;
+            Ok::<_, io::Error>(())
+        })
+    });
+
+    struct MyResolver {
+        trust_dns: TokioAsyncResolver,
+    };
+
+    impl Resolve for MyResolver {
+        fn lookup<'a>(
+            &'a self,
+            host: &'a str,
+            port: u16,
+        ) -> LocalBoxFuture<'a, Result<Vec<SocketAddr>, Box<dyn std::error::Error>>> {
+            Box::pin(async move {
+                let res = self
+                    .trust_dns
+                    .lookup_ip(host)
+                    .await?
+                    .iter()
+                    .map(|ip| SocketAddr::new(ip, port))
+                    .collect();
+                Ok(res)
+            })
+        }
+    }
+
+    let resolver = MyResolver {
+        trust_dns: TokioAsyncResolver::tokio_from_system_conf().unwrap(),
+    };
+
+    let resolver = Resolver::new_custom(resolver);
+
+    let factory = actix_connect::new_connector_factory(resolver);
 
     let mut conn = factory.new_service(()).await.unwrap();
     let con = conn.call(Connect::with("10", srv.addr())).await.unwrap();

--- a/actix-tls/tests/test_connect.rs
+++ b/actix-tls/tests/test_connect.rs
@@ -97,7 +97,7 @@ async fn test_custom_resolver() {
 
     struct MyResolver {
         trust_dns: TokioAsyncResolver,
-    };
+    }
 
     impl Resolve for MyResolver {
         fn lookup<'a>(

--- a/actix-utils/Cargo.toml
+++ b/actix-utils/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 actix-codec = "0.4.0-beta.1"
-actix-rt = "2.0.0-beta.2"
+actix-rt = { version = "2.0.0-beta.2", default-features = false }
 actix-service = "2.0.0-beta.3"
 
 futures-core = { version = "0.3.7", default-features = false }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `trust-dns` dependencies. 
Use `tokio::net::lookup_host` for simple dns lookup to improve compile time and reduce deps.

Make `Resolver` an enum type that accept custom `Resolve` trait object for custom resolver implementation.

Remove `either` and `futures-util` dep and simplify the connector and service logic.

Rework `connect` mod and remove duplicated iterator types. Reduce nested `Either` type and simplify Addrs to an enum.

export `webpki_roots::TLS_SERVER_ROOTS` in `connect` mod and remove it from `accept` mod. This is a type used only on client

Add more `connect` mod doc.

Remove commented code from `actix-rt`

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
