### PR TITLE
expose create_tcp_listener function. do not enable reuse_addr on windows

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * Hidden `ServerBuilder::start` method has been removed. Use `ServerBuilder::run`. [#246]
+* Expose `builder::create_tcp_listener`. Don't set reuseaddr on windows. [#249]
 
 [#246]: https://github.com/actix/actix-net/pull/246
+[#249]: https://github.com/actix/actix-net/pull/249
 
 
 ## 2.0.0-beta.2 - 2021-01-03

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -472,13 +472,18 @@ pub(super) fn bind_addr<S: ToSocketAddrs>(
     }
 }
 
-fn create_tcp_listener(addr: StdSocketAddr, backlog: u32) -> io::Result<MioTcpListener> {
+pub fn create_tcp_listener(addr: StdSocketAddr, backlog: u32) -> io::Result<MioTcpListener> {
     let socket = match addr {
         StdSocketAddr::V4(_) => MioTcpSocket::new_v4()?,
         StdSocketAddr::V6(_) => MioTcpSocket::new_v6()?,
     };
 
-    socket.set_reuseaddr(true)?;
+    // https://github.com/actix/actix-web/issues/1913
+    #[cfg(not(windows))]
+    {
+        socket.set_reuseaddr(true)?;
+    }
+
     socket.bind(addr)?;
     socket.listen(backlog)
 }

--- a/actix-server/src/lib.rs
+++ b/actix-server/src/lib.rs
@@ -15,7 +15,7 @@ mod test_server;
 mod waker_queue;
 mod worker;
 
-pub use self::builder::ServerBuilder;
+pub use self::builder::{create_tcp_listener, ServerBuilder};
 pub use self::config::{ServiceConfig, ServiceRuntime};
 pub use self::server::Server;
 pub use self::service::ServiceFactory;


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Expose `actix_server::builder::create_tcp_listener` function. With it actix-web can detch it's own tcplistener constructor function.
Do not set reuse_addr to true on windows platform. https://github.com/actix/actix-web/issues/1913


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
