### PR TITLE
fix actix-tls changelog

### DIFF
--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2021-xx-xx
 * Remove `trust-dns-proto` and `trust-dns-resolver` [#248]
-* Use `tokio::net::lookup_host` as simple and basic default resolver [#248]
+* Use `std::net::ToSocketAddrs::to_socket_addrs` as simple and basic default resolver [#248]
 * Add `Resolve` trait for custom dns resolver. [#248]
 * Add `Resolver::new_custom` function to construct custom resolvers. [#248]
 * Export `webpki_roots::TLS_SERVER_ROOTS` in `actix_tls::connect` mod and remove

--- a/actix-tls/src/connect/resolve.rs
+++ b/actix-tls/src/connect/resolve.rs
@@ -135,6 +135,7 @@ impl Resolver {
             format!("{}:{}", host, req.port())
         };
 
+        // spawn blocking dns lookup in thread pool.
         spawn_blocking(move || std::net::ToSocketAddrs::to_socket_addrs(&host))
     }
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Doc fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This is a follow PR for https://github.com/actix/actix-net/pull/248

The changelog is wrong on the default resolver. `spawn_blocking` is used to static dispatch default dns lookup future.(tokio::net::lookup_host does the same internally)  

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
