### PR TITLE
remove tokio runners

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,6 +2,16 @@
 
 ## Unreleased - 2021-xx-xx
 
+* Remove `run_in_tokio` and `attach_to_tokio`. [#253]
+* Remove `AsyncSystemRunner`. [#253]
+* Return `JoinHandle` from `actix_rt::spawn`. [#253]
+* Remove old `Arbiter::spawn`. Implementation is now inlined into `actix_rt::spawn`. [#253]
+* Rename `Arbiter::{send => spawn}` and `Arbiter::{exec_fn => spawn_fn}`. [#253]
+* Remove `Arbiter::exec`. [#253]
+* Remove deprecated `Arbiter::local_join`. [#253]
+
+[#253]: https://github.com/actix/actix-net/pull/253
+
 
 ## 2.0.0-beta.2 - 2021-01-09
 * Add `task` mod with re-export of `tokio::task::{spawn_blocking, yield_now, JoinHandle}` [#245]

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,13 +2,12 @@
 
 ## Unreleased - 2021-xx-xx
 
-* Remove `run_in_tokio` and `attach_to_tokio`. [#253]
-* Remove `AsyncSystemRunner`. [#253]
+* Remove `run_in_tokio`, `attach_to_tokio` and `AsyncSystemRunner`. [#253]
 * Return `JoinHandle` from `actix_rt::spawn`. [#253]
 * Remove old `Arbiter::spawn`. Implementation is now inlined into `actix_rt::spawn`. [#253]
 * Rename `Arbiter::{send => spawn}` and `Arbiter::{exec_fn => spawn_fn}`. [#253]
 * Remove `Arbiter::exec`. [#253]
-* Remove deprecated `Arbiter::local_join`. [#253]
+* Remove deprecated `Arbiter::local_join` and `Arbiter::is_running`. [#253]
 
 [#253]: https://github.com/actix/actix-net/pull/253
 

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -22,6 +22,7 @@ macros = ["actix-macros"]
 [dependencies]
 actix-macros = { version = "0.2.0-beta.1", optional = true }
 
+futures-core = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["rt", "net", "parking_lot", "signal", "sync", "time"] }
 
 [dev-dependencies]

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -87,12 +87,6 @@ impl Arbiter {
         })
     }
 
-    /// Check if current arbiter is running.
-    #[deprecated(note = "Thread local variables for running state of Arbiter is removed")]
-    pub fn is_running() -> bool {
-        false
-    }
-
     /// Stop arbiter from continuing it's event loop.
     pub fn stop(&self) {
         let _ = self.sender.send(ArbiterCommand::Stop);
@@ -122,7 +116,7 @@ impl Arbiter {
 
                     // register arbiter
                     let _ = System::current()
-                        .sys()
+                        .tx()
                         .send(SystemCommand::RegisterArbiter(id, arb));
 
                     // start arbiter controller
@@ -131,7 +125,7 @@ impl Arbiter {
 
                     // deregister arbiter
                     let _ = System::current()
-                        .sys()
+                        .tx()
                         .send(SystemCommand::DeregisterArbiter(id));
                 }
             })
@@ -243,6 +237,7 @@ struct ArbiterController {
 
 impl Drop for ArbiterController {
     fn drop(&mut self) {
+        // panics can only occur with spawn_fn calls
         if thread::panicking() {
             if System::current().stop_on_panic() {
                 eprintln!("Panic in Arbiter thread, shutting down system.");

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -149,7 +149,7 @@ impl Arbiter {
     ///
     /// If you require a result, include a response channel in the future.
     ///
-    /// Returns true if function was sent successfully and false if the Arbiter has died.
+    /// Returns true if future was sent successfully and false if the Arbiter has died.
     pub fn spawn<Fut>(&self, future: Fut) -> bool
     where
         Fut: Future<Output = ()> + Unpin + Send + 'static,

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -66,8 +66,7 @@ impl Default for Arbiter {
 }
 
 impl Arbiter {
-    /// TODO: make pub(crate) again
-    pub fn new_system(local: &LocalSet) -> Self {
+    pub(crate) fn new_system(local: &LocalSet) -> Self {
         let (tx, rx) = unbounded_channel();
 
         let arb = Arbiter::with_sender(tx);

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -8,6 +8,8 @@
 
 use std::future::Future;
 
+use tokio::task::JoinHandle;
+
 // Cannot define a main macro when compiled into test harness.
 // Workaround for https://github.com/rust-lang/rust/issues/62127.
 #[cfg(all(feature = "macros", not(test)))]
@@ -26,13 +28,13 @@ pub use self::system::System;
 /// Spawns a future on the current arbiter.
 ///
 /// # Panics
-/// This function panics if actix system is not running.
+/// Panics if Actix system is not running.
 #[inline]
-pub fn spawn<F>(f: F)
+pub fn spawn<Fut>(f: Fut) -> JoinHandle<()>
 where
-    F: Future<Output = ()> + 'static,
+    Fut: Future<Output = ()> + 'static,
 {
-    Arbiter::spawn(f)
+    tokio::task::spawn_local(f)
 }
 
 /// Asynchronous signal handling

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -17,7 +17,7 @@ static SYSTEM_COUNT: AtomicUsize = AtomicUsize::new(0);
 #[derive(Clone, Debug)]
 pub struct System {
     id: usize,
-    sys: UnboundedSender<SystemCommand>,
+    tx: UnboundedSender<SystemCommand>,
     arbiter: Arbiter,
     stop_on_panic: bool,
 }
@@ -34,7 +34,7 @@ impl System {
         stop_on_panic: bool,
     ) -> Self {
         let sys = System {
-            sys,
+            tx: sys,
             arbiter,
             stop_on_panic,
             id: SYSTEM_COUNT.fetch_add(1, Ordering::SeqCst),
@@ -102,11 +102,11 @@ impl System {
 
     /// Stop the system with a particular exit code.
     pub fn stop_with_code(&self, code: i32) {
-        let _ = self.sys.send(SystemCommand::Exit(code));
+        let _ = self.tx.send(SystemCommand::Exit(code));
     }
 
-    pub(crate) fn sys(&self) -> &UnboundedSender<SystemCommand> {
-        &self.sys
+    pub(crate) fn tx(&self) -> &UnboundedSender<SystemCommand> {
+        &self.tx
     }
 
     /// Return status of 'stop_on_panic' option which controls whether the System is stopped when an

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -401,7 +401,7 @@ impl Accept {
 
                         // after the sleep a Timer interest is sent to Accept Poll
                         let waker = self.waker.clone();
-                        System::current().arbiter().send(Box::pin(async move {
+                        System::current().arbiter().spawn(Box::pin(async move {
                             sleep_until(Instant::now() + Duration::from_millis(510)).await;
                             waker.wake(WakerInterest::Timer);
                         }));

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -6,7 +6,7 @@ use std::{io, mem};
 
 use actix_rt::net::TcpStream;
 use actix_rt::time::{sleep_until, Instant};
-use actix_rt::{spawn, System};
+use actix_rt::{self as rt, System};
 use log::{error, info};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::oneshot;
@@ -288,7 +288,7 @@ impl ServerBuilder {
 
             // start http server actor
             let server = self.server.clone();
-            spawn(self);
+            rt::spawn(self);
             server
         }
     }
@@ -364,7 +364,7 @@ impl ServerBuilder {
 
                     let fut = join_all(iter);
 
-                    spawn(async move {
+                    rt::spawn(async move {
                         let _ = fut.await;
                         if let Some(tx) = completion {
                             let _ = tx.send(());
@@ -373,16 +373,16 @@ impl ServerBuilder {
                             let _ = tx.send(());
                         }
                         if exit {
-                            spawn(async {
+                            rt::spawn(async {
                                 sleep_until(Instant::now() + Duration::from_millis(300)).await;
                                 System::current().stop();
                             });
                         }
-                    })
+                    });
                 } else {
                     // we need to stop system if server was spawned
                     if self.exit {
-                        spawn(async {
+                        rt::spawn(async {
                             sleep_until(Instant::now() + Duration::from_millis(300)).await;
                             System::current().stop();
                         });

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -172,7 +172,7 @@ impl Worker {
         let avail = availability.clone();
 
         // every worker runs in it's own arbiter.
-        Arbiter::new().send(Box::pin(async move {
+        Arbiter::new().spawn(Box::pin(async move {
             availability.set(false);
             let mut wrk = MAX_CONNS_COUNTER.with(move |conns| Worker {
                 rx,


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
- Remove `run_in_tokio` and `attach_to_tokio`.
- Remove `AsyncSystemRunner`.
- Return `JoinHandle` from `actix_rt::spawn`.
	- Remove old `Arbiter::spawn`. Implementation is now inlined into `actix_rt::spawn`.
- Rename `Arbiter::{send => spawn}` and `Arbiter::{exec_fn => spawn_fn}`.
- Remove `Arbiter::exec`.
- Remove deprecated `Arbiter::local_join`.