### PR TITLE
express spawn fn as spawn fut

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,16 +2,18 @@
 
 ## Unreleased - 2021-xx-xx
 
+* Rename `Arbiter => Worker`. [#254]
 * Remove `run_in_tokio`, `attach_to_tokio` and `AsyncSystemRunner`. [#253]
 * Return `JoinHandle` from `actix_rt::spawn`. [#253]
-* Remove old `Arbiter::spawn`. Implementation is now inlined into `actix_rt::spawn`. [#253]
-* Rename `Arbiter::{send => spawn}` and `Arbiter::{exec_fn => spawn_fn}`. [#253]
-* Remove `Arbiter::exec`. [#253]
-* Remove deprecated `Arbiter::local_join` and `Arbiter::is_running`. [#253]
-* Rename `Arbiter => Worker`. [#254]
+* Remove old `Worker::spawn`. Implementation is now inlined into `actix_rt::spawn`. [#253]
+* Rename `Worker::{send => spawn}` and `Worker::{exec_fn => spawn_fn}`. [#253]
+* Remove `Worker::exec`. [#253]
+* Remove deprecated `Worker::local_join` and `Worker::is_running`. [#253]
+* `Worker::spawn` now accepts !Unpin futures. [#256]
 
 [#253]: https://github.com/actix/actix-net/pull/253
 [#254]: https://github.com/actix/actix-net/pull/254
+[#256]: https://github.com/actix/actix-net/pull/256
 
 
 ## 2.0.0-beta.2 - 2021-01-09

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -8,6 +8,7 @@
 * Remove old `Worker::spawn`. Implementation is now inlined into `actix_rt::spawn`. [#253]
 * Rename `Worker::{send => spawn}` and `Worker::{exec_fn => spawn_fn}`. [#253]
 * Remove `Worker::exec`. [#253]
+* Remove `System::arbiter`. [#256]
 * Remove deprecated `Worker::local_join` and `Worker::is_running`. [#253]
 * `Worker::spawn` now accepts !Unpin futures. [#256]
 

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -27,4 +27,3 @@ tokio = { version = "1", features = ["rt", "net", "parking_lot", "signal", "sync
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-futures-util = { version = "0.3.7", default-features = true, features = ["alloc"] }

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -25,18 +25,6 @@ pub use self::runtime::Runtime;
 pub use self::system::System;
 pub use self::worker::Worker;
 
-/// Spawns a future on the current [Arbiter].
-///
-/// # Panics
-/// Panics if Actix system is not running.
-#[inline]
-pub fn spawn<Fut>(f: Fut) -> JoinHandle<()>
-where
-    Fut: Future<Output = ()> + 'static,
-{
-    tokio::task::spawn_local(f)
-}
-
 pub mod signal {
     //! Asynchronous signal handling (Tokio re-exports).
 
@@ -71,4 +59,16 @@ pub mod task {
     //! Task management (Tokio re-exports).
 
     pub use tokio::task::{spawn_blocking, yield_now, JoinHandle};
+}
+
+/// Spawns a future on the current [Worker].
+///
+/// # Panics
+/// Panics if Actix system is not running.
+#[inline]
+pub fn spawn<Fut>(f: Fut) -> JoinHandle<()>
+where
+    Fut: Future<Output = ()> + 'static,
+{
+    tokio::task::spawn_local(f)
 }

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -24,6 +24,7 @@ static SYSTEM_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub struct System {
     id: usize,
     sys_tx: mpsc::UnboundedSender<SystemCommand>,
+    // TODO: which worker is this exactly
     worker: Worker,
 }
 
@@ -63,6 +64,9 @@ impl System {
     }
 
     /// Get current running system.
+    ///
+    /// # Panics
+    /// Panics if no system is registered on the current thread.
     pub fn current() -> System {
         CURRENT.with(|cell| match *cell.borrow() {
             Some(ref sys) => sys.clone(),
@@ -111,6 +115,12 @@ impl System {
 
     pub(crate) fn tx(&self) -> &mpsc::UnboundedSender<SystemCommand> {
         &self.sys_tx
+    }
+
+    // TODO: give clarity on which worker this is; previous documented as returning "system worker"
+    /// Get shared reference to a worker.
+    pub fn worker(&self) -> &Worker {
+        &self.worker
     }
 
     /// This function will start Tokio runtime and will finish once the `System::stop()` message

--- a/actix-rt/src/worker.rs
+++ b/actix-rt/src/worker.rs
@@ -66,6 +66,9 @@ impl Worker {
     /// Spawn new thread and run event loop in spawned thread.
     ///
     /// Returns handle of newly created worker.
+    ///
+    /// # Panics
+    /// Panics if a [System] not registered on the current thread.
     pub fn new() -> Worker {
         let id = COUNT.fetch_add(1, Ordering::Relaxed);
         let name = format!("actix-rt:worker:{}", id);

--- a/actix-rt/src/worker.rs
+++ b/actix-rt/src/worker.rs
@@ -197,11 +197,6 @@ impl Worker {
 
     /// Call a function with a shared reference to an item in this worker's thread-local storage.
     ///
-    /// # Examples
-    /// ```
-    ///
-    /// ```
-    ///
     /// # Panics
     /// Panics if item is not in worker's thread-local item storage.
     pub fn get_item<T: 'static, F, R>(mut f: F) -> R
@@ -252,7 +247,7 @@ impl Future for WorkerRunner {
                 // channel closed; no more messages can be received
                 None => return Poll::Ready(()),
 
-                // process arbiter command
+                // process worker command
                 Some(item) => match item {
                     WorkerCommand::Stop => return Poll::Ready(()),
                     WorkerCommand::Execute(task_fut) => {

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -185,3 +185,15 @@ fn system_name_cow_string() {
     let _ = System::new("test-system".to_owned());
     System::current().stop();
 }
+
+#[test]
+#[should_panic]
+fn no_system_current_panic() {
+    System::current();
+}
+
+#[test]
+#[should_panic]
+fn no_system_worker_new_panic() {
+    Worker::new();
+}

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -136,12 +136,10 @@ fn worker_drop_no_panic_fn() {
 
 #[test]
 fn worker_drop_no_panic_fut() {
-    use futures_util::future::lazy;
-
     let _ = System::new("test-system");
 
     let mut worker = Worker::new();
-    worker.spawn(lazy(|_| panic!("test")));
+    worker.spawn(async { panic!("test") });
 
     worker.stop();
     worker.join().unwrap();

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 use std::{io, thread};
 
 use actix_rt::{
-    self as rt,
     time::{sleep_until, Instant},
     System,
 };
@@ -404,7 +403,7 @@ impl Accept {
 
                         // after the sleep a Timer interest is sent to Accept Poll
                         let waker = self.waker.clone();
-                        rt::spawn(async move {
+                        System::current().worker().spawn(async move {
                             sleep_until(Instant::now() + Duration::from_millis(510)).await;
                             waker.wake(WakerInterest::Timer);
                         });

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -1,8 +1,11 @@
 use std::time::Duration;
 use std::{io, thread};
 
-use actix_rt::time::{sleep_until, Instant};
-use actix_rt::System;
+use actix_rt::{
+    self as rt,
+    time::{sleep_until, Instant},
+    System,
+};
 use log::{error, info};
 use mio::{Interest, Poll, Token as MioToken};
 use slab::Slab;
@@ -401,10 +404,11 @@ impl Accept {
 
                         // after the sleep a Timer interest is sent to Accept Poll
                         let waker = self.waker.clone();
-                        System::current().arbiter().spawn(Box::pin(async move {
+                        rt::spawn(async move {
                             sleep_until(Instant::now() + Duration::from_millis(510)).await;
                             waker.wake(WakerInterest::Timer);
-                        }));
+                        });
+
                         return;
                     }
                 }


### PR DESCRIPTION
## PR Type
Refactor


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
`spawn_fn` now uses `spawn(async { f() })` 