### PR TITLE
retry on EINTR in accept loop

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2021-xx-xx
 * Hidden `ServerBuilder::start` method has been removed. Use `ServerBuilder::run`. [#246]
+* Add retry for EINTR(`io::Interrupted`) in `Accept`'s poll loop.
 
 [#246]: https://github.com/actix/actix-net/pull/246
 

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,9 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * Hidden `ServerBuilder::start` method has been removed. Use `ServerBuilder::run`. [#246]
-* Add retry for EINTR(`io::Interrupted`) in `Accept`'s poll loop.
+* Add retry for EINTR(`io::Interrupted`) in `Accept`'s poll loop. [#264]
 
 [#246]: https://github.com/actix/actix-net/pull/246
+[#264]: https://github.com/actix/actix-net/pull/264
 
 
 ## 2.0.0-beta.2 - 2021-01-03

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -161,9 +161,13 @@ impl Accept {
         let mut events = mio::Events::with_capacity(128);
 
         loop {
-            self.poll
-                .poll(&mut events, None)
-                .unwrap_or_else(|e| panic!("Poll error: {}", e));
+            if let Err(e) = self.poll.poll(&mut events, None) {
+                if matches!(e.kind(), std::io::ErrorKind::Interrupted) {
+                    continue;
+                } else {
+                    panic!("Poll error: {}", e);
+                }
+            }
 
             for event in events.iter() {
                 let token = event.token();

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -162,10 +162,13 @@ impl Accept {
 
         loop {
             if let Err(e) = self.poll.poll(&mut events, None) {
-                if matches!(e.kind(), std::io::ErrorKind::Interrupted) {
-                    continue;
-                } else {
-                    panic!("Poll error: {}", e);
+                match e.kind() {
+                    std::io::ErrorKind::Interrupted => {
+                        continue;
+                    }
+                    _ => {
+                        panic!("Poll error: {}", e);
+                    }
                 }
             }
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Currently, EINTR which equals std::io::ErrorKind::Interrupted will trigger a panic. This change captures it and retry poll. 

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
closes #263 
