### PR TITLE
use static dispatch on signal handling. reduce allocation

### DIFF
--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -26,8 +26,8 @@ macros = ["actix-macros"]
 actix-macros = { version = "0.2.0", optional = true }
 
 futures-core = { version = "0.3", default-features = false }
-tokio = { version = "1", features = ["rt", "net", "parking_lot", "signal", "sync", "time"] }
+tokio = { version = "1.2", features = ["rt", "net", "parking_lot", "signal", "sync", "time"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.2", features = ["full"] }
 hyper = { version = "0.14", default-features = false, features = ["server", "tcp", "http1"] }

--- a/actix-server/src/signals.rs
+++ b/actix-server/src/signals.rs
@@ -21,7 +21,7 @@ pub(crate) enum Signal {
 pub(crate) struct Signals {
     srv: Server,
     #[cfg(not(unix))]
-    signals: LocalBoxFuture<'static, std::io::Result<()>>,
+    signals: futures_core::future::LocalBoxFuture<'static, std::io::Result<()>>,
     #[cfg(unix)]
     signals: Vec<(Signal, actix_rt::signal::unix::Signal)>,
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Bump to tokio 1.2 for actix-rt in order to get poll_recv method for unix signals.

Remove boxed future for unix signal handling in `actix_server::signals::Signals`. reduce allocation.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
