### PR TITLE
add System::try_current

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * Add `Arbiter::handle` to get a handle of an owned Arbiter. [#274]
+* Add `System::try_current` for situations where actix may or may not be running a System. [#???]
 
 [#274]: https://github.com/actix/actix-net/pull/274
+[#???]: https://github.com/actix/actix-net/pull/???
 
 
 ## 2.0.1 - 2021-02-06

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,10 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * Add `Arbiter::handle` to get a handle of an owned Arbiter. [#274]
-* Add `System::try_current` for situations where actix may or may not be running a System. [#???]
+* Add `System::try_current` for situations where actix may or may not be running a System. [#275]
 
 [#274]: https://github.com/actix/actix-net/pull/274
-[#???]: https://github.com/actix/actix-net/pull/???
+[#275]: https://github.com/actix/actix-net/pull/275
 
 
 ## 2.0.1 - 2021-02-06

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -100,6 +100,15 @@ impl System {
         })
     }
 
+    /// Try to get current running system.
+    ///
+    /// Returns `None` if no System has been started.
+    ///
+    /// Contrary to `current`, this never panics.
+    pub fn try_current() -> Option<System> {
+        CURRENT.with(|cell| cell.borrow().clone())
+    }
+
     /// Get handle to a the System's initial [Arbiter].
     pub fn arbiter(&self) -> &ArbiterHandle {
         &self.arbiter_handle

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -288,3 +288,13 @@ fn new_arbiter_with_tokio() {
 
     assert_eq!(false, counter.load(Ordering::SeqCst));
 }
+
+#[test]
+fn try_current_no_system() {
+    assert!(System::try_current().is_none())
+}
+
+#[test]
+fn try_current_with_system() {
+    System::new().block_on(async { assert!(System::try_current().is_some()) });
+}


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Add `System::try_current`. Use case is to be able to stop Systems whether they exist or not without panicking.

Tokio uses a Result for their `Handle::try_current` method but it seems unecessary to make a new type just for it when you can just `.ok_or(...)` at the call site.