### PR TITLE
add RcService type and rc_service construct function

### DIFF
--- a/actix-service/CHANGES.md
+++ b/actix-service/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * Add default `Service` trait impl for `Rc<S: Service>` and `&S: Service`. [#288]
+* Add `boxed::rc_service` function for constructing `boxed::RcService` type [#290]
 
 [#288]: https://github.com/actix/actix-net/pull/288
+[#290]: https://github.com/actix/actix-net/pull/290
 
 
 ## 2.0.0-beta.4 - 2021-02-04

--- a/actix-service/src/boxed.rs
+++ b/actix-service/src/boxed.rs
@@ -1,7 +1,6 @@
-use alloc::boxed::Box;
+use alloc::{boxed::Box, rc::Rc};
 use core::{
     future::Future,
-    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -10,12 +9,34 @@ use crate::{Service, ServiceFactory};
 
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
-pub type BoxService<Req, Res, Err> =
-    Box<dyn Service<Req, Response = Res, Error = Err, Future = BoxFuture<Result<Res, Err>>>>;
+macro_rules! service_object {
+    ($name: ident, $type: tt, $fn_name: ident) => {
+        /// Type alias for service trait object.
+        pub type $name<Req, Res, Err> = $type<
+            dyn Service<Req, Response = Res, Error = Err, Future = BoxFuture<Result<Res, Err>>>,
+        >;
 
+        /// Create service trait object.
+        pub fn $fn_name<S, Req>(service: S) -> $name<Req, S::Response, S::Error>
+        where
+            S: Service<Req> + 'static,
+            Req: 'static,
+            S::Future: 'static,
+        {
+            $type::new(ServiceWrapper(service))
+        }
+    };
+}
+
+service_object!(BoxService, Box, service);
+
+service_object!(RcService, Rc, rc_service);
+
+/// Type alias for service factory trait object that would produce a trait object service
+/// (`BoxService`, `RcService`, etc.)
 pub struct BoxServiceFactory<Cfg, Req, Res, Err, InitErr>(Inner<Cfg, Req, Res, Err, InitErr>);
 
-/// Create boxed service factory
+/// Create service factory trait object.
 pub fn factory<SF, Req>(
     factory: SF,
 ) -> BoxServiceFactory<SF::Config, Req, SF::Response, SF::Error, SF::InitError>
@@ -28,20 +49,7 @@ where
     SF::Error: 'static,
     SF::InitError: 'static,
 {
-    BoxServiceFactory(Box::new(FactoryWrapper {
-        factory,
-        _t: PhantomData,
-    }))
-}
-
-/// Create boxed service
-pub fn service<S, Req>(service: S) -> BoxService<Req, S::Response, S::Error>
-where
-    S: Service<Req> + 'static,
-    Req: 'static,
-    S::Future: 'static,
-{
-    Box::new(ServiceWrapper(service, PhantomData))
+    BoxServiceFactory(Box::new(FactoryWrapper(factory)))
 }
 
 type Inner<C, Req, Res, Err, InitErr> = Box<
@@ -66,9 +74,9 @@ where
 {
     type Response = Res;
     type Error = Err;
-    type InitError = InitErr;
     type Config = C;
     type Service = BoxService<Req, Res, Err>;
+    type InitError = InitErr;
 
     type Future = BoxFuture<Result<Self::Service, InitErr>>;
 
@@ -77,12 +85,9 @@ where
     }
 }
 
-struct FactoryWrapper<SF, Req, Cfg> {
-    factory: SF,
-    _t: PhantomData<(Req, Cfg)>,
-}
+struct FactoryWrapper<SF>(SF);
 
-impl<SF, Req, Cfg, Res, Err, InitErr> ServiceFactory<Req> for FactoryWrapper<SF, Req, Cfg>
+impl<SF, Req, Cfg, Res, Err, InitErr> ServiceFactory<Req> for FactoryWrapper<SF>
 where
     Req: 'static,
     Res: 'static,
@@ -95,34 +100,20 @@ where
 {
     type Response = Res;
     type Error = Err;
-    type InitError = InitErr;
     type Config = Cfg;
     type Service = BoxService<Req, Res, Err>;
+    type InitError = InitErr;
     type Future = BoxFuture<Result<Self::Service, Self::InitError>>;
 
     fn new_service(&self, cfg: Cfg) -> Self::Future {
-        let fut = self.factory.new_service(cfg);
-        Box::pin(async {
-            let res = fut.await;
-            res.map(ServiceWrapper::boxed)
-        })
+        let f = self.0.new_service(cfg);
+        Box::pin(async { f.await.map(|s| Box::new(ServiceWrapper(s)) as _) })
     }
 }
 
-struct ServiceWrapper<S: Service<Req>, Req>(S, PhantomData<Req>);
+struct ServiceWrapper<S>(S);
 
-impl<S, Req> ServiceWrapper<S, Req>
-where
-    S: Service<Req> + 'static,
-    Req: 'static,
-    S::Future: 'static,
-{
-    fn boxed(service: S) -> BoxService<Req, S::Response, S::Error> {
-        Box::new(ServiceWrapper(service, PhantomData))
-    }
-}
-
-impl<S, Req, Res, Err> Service<Req> for ServiceWrapper<S, Req>
+impl<S, Req, Res, Err> Service<Req> for ServiceWrapper<S>
 where
     S: Service<Req, Response = Res, Error = Err>,
     S::Future: 'static,

--- a/actix-service/src/lib.rs
+++ b/actix-service/src/lib.rs
@@ -204,7 +204,7 @@ where
 
 impl<S, Req> Service<Req> for Rc<S>
 where
-    S: Service<Req>,
+    S: Service<Req> + ?Sized,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/actix-service/src/lib.rs
+++ b/actix-service/src/lib.rs
@@ -211,11 +211,11 @@ where
     type Future = S::Future;
 
     fn poll_ready(&self, ctx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        (&**self).poll_ready(ctx)
+        (**self).poll_ready(ctx)
     }
 
     fn call(&self, request: Req) -> S::Future {
-        (&**self).call(request)
+        (**self).call(request)
     }
 }
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Add `Rc<dyn Service>` type alias and constructor function.
This would enable easy constructing of trait object type as S: Service + Clone. 

Remove extra & introduced by #288

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
