### PR TITLE
Remove unused TcpConnectService

### DIFF
--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -13,7 +13,7 @@
 [#295]: https://github.com/actix/actix-net/pull/295
 [#296]: https://github.com/actix/actix-net/pull/296
 [#297]: https://github.com/actix/actix-net/pull/297
-[#299]: https://github.com/actix/actix-net/pull/298
+[#299]: https://github.com/actix/actix-net/pull/299
 
 
 ## 3.0.0-beta.4 - 2021-02-24

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -8,12 +8,12 @@
 * Add `connect::ssl::native_tls` module for native tls support. [#295]
 * Rename `accept::{nativetls => native_tls}`. [#295]
 * Remove `connect::TcpConnectService` type. service caller expect a `TcpStream` should use 
-  `connect::ConnectService` instead and call `Connection<T, TcpStream>::into_parts`. [#298]
+  `connect::ConnectService` instead and call `Connection<T, TcpStream>::into_parts`. [#299]
 
 [#295]: https://github.com/actix/actix-net/pull/295
 [#296]: https://github.com/actix/actix-net/pull/296
 [#297]: https://github.com/actix/actix-net/pull/297
-[#298]: https://github.com/actix/actix-net/pull/298
+[#299]: https://github.com/actix/actix-net/pull/298
 
 
 ## 3.0.0-beta.4 - 2021-02-24

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -7,10 +7,13 @@
 * Remove `connect::ssl::openssl::OpensslConnectService`. [#297]
 * Add `connect::ssl::native_tls` module for native tls support. [#295]
 * Rename `accept::{nativetls => native_tls}`. [#295]
+* Remove `connect::TcpConnectService` type. service caller expect a `TcpStream` should use 
+  `connect::ConnectService` instead and call `Connection<T, TcpStream>::into_parts`. [#298]
 
 [#295]: https://github.com/actix/actix-net/pull/295
 [#296]: https://github.com/actix/actix-net/pull/296
 [#297]: https://github.com/actix/actix-net/pull/297
+[#298]: https://github.com/actix/actix-net/pull/298
 
 
 ## 3.0.0-beta.4 - 2021-02-24

--- a/actix-tls/src/connect/mod.rs
+++ b/actix-tls/src/connect/mod.rs
@@ -26,20 +26,20 @@ pub mod ssl;
 mod uri;
 
 use actix_rt::net::TcpStream;
-use actix_service::{pipeline, pipeline_factory, Service, ServiceFactory};
+use actix_service::{Service, ServiceFactory};
 
 pub use self::connect::{Address, Connect, Connection};
 pub use self::connector::{TcpConnector, TcpConnectorFactory};
 pub use self::error::ConnectError;
 pub use self::resolve::{Resolve, Resolver, ResolverFactory};
-pub use self::service::{ConnectService, ConnectServiceFactory, TcpConnectService};
+pub use self::service::{ConnectService, ConnectServiceFactory};
 
 /// Create TCP connector service.
 pub fn new_connector<T: Address + 'static>(
     resolver: Resolver,
 ) -> impl Service<Connect<T>, Response = Connection<T, TcpStream>, Error = ConnectError> + Clone
 {
-    pipeline(resolver).and_then(TcpConnector)
+    ConnectServiceFactory::new(resolver).service()
 }
 
 /// Create TCP connector service factory.
@@ -52,7 +52,7 @@ pub fn new_connector_factory<T: Address + 'static>(
     Error = ConnectError,
     InitError = (),
 > + Clone {
-    pipeline_factory(ResolverFactory::new(resolver)).and_then(TcpConnectorFactory)
+    ConnectServiceFactory::new(resolver)
 }
 
 /// Create connector service with default parameters.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `actix_tls::connect::TcpConnectService`. This service type share almost all the logic with `connect::ConnectService` with only the return type different as `TcpStream`. This would be also achieveable with `ConnectService`'s return type with `Connectition<Address, TcpStream>::into_parts()` API.

Simplify `TcpConnectorService`'s service call future.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
