### PR TITLE
Reduce size of Conn by removing unused addr field

### DIFF
--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -391,11 +391,10 @@ impl Accept {
                 .expect("ServerSocketInfo is removed from Slab");
 
             match info.lst.accept() {
-                Ok((io, addr)) => {
+                Ok(io) => {
                     let msg = Conn {
                         io,
                         token: info.token,
-                        peer: Some(addr),
                     };
                     self.accept_one(sockets, msg);
                 }

--- a/actix-server/src/socket.rs
+++ b/actix-server/src/socket.rs
@@ -40,15 +40,11 @@ impl MioListener {
         }
     }
 
-    pub(crate) fn accept(&self) -> io::Result<(MioStream, SocketAddr)> {
+    pub(crate) fn accept(&self) -> io::Result<MioStream> {
         match *self {
-            MioListener::Tcp(ref lst) => lst
-                .accept()
-                .map(|(stream, addr)| (MioStream::Tcp(stream), SocketAddr::Tcp(addr))),
+            MioListener::Tcp(ref lst) => lst.accept().map(|(stream, _)| MioStream::Tcp(stream)),
             #[cfg(unix)]
-            MioListener::Uds(ref lst) => lst
-                .accept()
-                .map(|(stream, addr)| (MioStream::Uds(stream), SocketAddr::Uds(addr))),
+            MioListener::Uds(ref lst) => lst.accept().map(|(stream, _)| MioStream::Uds(stream)),
         }
     }
 }

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 
 use crate::service::{BoxedServerService, InternalServiceFactory};
-use crate::socket::{MioStream, SocketAddr};
+use crate::socket::MioStream;
 use crate::waker_queue::{WakerInterest, WakerQueue};
 use crate::{join_all, Token};
 
@@ -31,7 +31,6 @@ pub(crate) struct StopCommand {
 pub(crate) struct Conn {
     pub io: MioStream,
     pub token: Token,
-    pub peer: Option<SocketAddr>,
 }
 
 static MAX_CONNS: AtomicUsize = AtomicUsize::new(25600);


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove unused field SocketAddr from `Conn` type. This would cut down it's size to half.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
