### PR TITLE
Refactor actix_server WorkerState::Restarting enum variant.

### DIFF
--- a/actix-server/src/config.rs
+++ b/actix-server/src/config.rs
@@ -7,14 +7,14 @@ use actix_service::{
     fn_service, IntoServiceFactory as IntoBaseServiceFactory,
     ServiceFactory as BaseServiceFactory,
 };
-use actix_utils::counter::CounterGuard;
+use actix_utils::{counter::CounterGuard, future::ready};
 use futures_core::future::LocalBoxFuture;
 use log::error;
 
 use crate::builder::bind_addr;
 use crate::service::{BoxedServerService, InternalServiceFactory, StreamService};
 use crate::socket::{MioStream, MioTcpListener, StdSocketAddr, StdTcpListener, ToSocketAddrs};
-use crate::{ready, Token};
+use crate::Token;
 
 pub struct ServiceConfig {
     pub(crate) services: Vec<(String, MioTcpListener)>,

--- a/actix-server/src/lib.rs
+++ b/actix-server/src/lib.rs
@@ -55,24 +55,6 @@ pub fn new() -> ServerBuilder {
     ServerBuilder::default()
 }
 
-// temporary Ready type for std::future::{ready, Ready}; Can be removed when MSRV surpass 1.48
-#[doc(hidden)]
-pub struct Ready<T>(Option<T>);
-
-pub(crate) fn ready<T>(t: T) -> Ready<T> {
-    Ready(Some(t))
-}
-
-impl<T> Unpin for Ready<T> {}
-
-impl<T> Future for Ready<T> {
-    type Output = T;
-
-    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(self.get_mut().0.take().unwrap())
-    }
-}
-
 // a poor man's join future. joined future is only used when starting/stopping the server.
 // pin_project and pinned futures are overkill for this task.
 pub(crate) struct JoinAll<T> {
@@ -131,6 +113,8 @@ impl<T> Future for JoinAll<T> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use actix_utils::future::ready;
 
     #[actix_rt::test]
     async fn test_join_all() {

--- a/actix-server/src/service.rs
+++ b/actix-server/src/service.rs
@@ -3,12 +3,15 @@ use std::net::SocketAddr;
 use std::task::{Context, Poll};
 
 use actix_service::{Service, ServiceFactory as BaseServiceFactory};
-use actix_utils::counter::CounterGuard;
+use actix_utils::{
+    counter::CounterGuard,
+    future::{ready, Ready},
+};
 use futures_core::future::LocalBoxFuture;
 use log::error;
 
 use crate::socket::{FromStream, MioStream};
-use crate::{ready, Ready, Token};
+use crate::Token;
 
 pub trait ServiceFactory<Stream: FromStream>: Send + Clone + 'static {
     type Factory: BaseServiceFactory<Stream, Config = ()>;

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use actix_rt::time::{sleep, Sleep};
 use actix_rt::{spawn, Arbiter};
 use actix_utils::counter::Counter;
-use futures_core::future::LocalBoxFuture;
+use futures_core::{future::LocalBoxFuture, ready};
 use log::{error, info, trace};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
@@ -396,27 +396,27 @@ impl Future for ServerWorker {
                 }
             },
             WorkerState::Restarting(idx, token, ref mut fut) => {
-                match fut.as_mut().poll(cx) {
-                    Poll::Ready(Ok(item)) => {
-                        // only interest in the first item?
-                        if let Some((token, service)) = item.into_iter().next() {
-                            trace!(
-                                "Service {:?} has been restarted",
-                                self.factories[idx].name(token)
-                            );
-                            self.services[token.0].created(service);
-                            self.state = WorkerState::Unavailable;
-                            return self.poll(cx);
-                        }
-                    }
-                    Poll::Ready(Err(_)) => {
-                        panic!(
-                            "Can not restart {:?} service",
-                            self.factories[idx].name(token)
-                        );
-                    }
-                    Poll::Pending => return Poll::Pending,
-                }
+                let item = ready!(fut.as_mut().poll(cx)).unwrap_or_else(|_| {
+                    panic!(
+                        "Can not restart {:?} service",
+                        self.factories[idx].name(token)
+                    )
+                });
+
+                // Only interest in the first item?
+                let (token, service) = item
+                    .into_iter()
+                    .next()
+                    .expect("No BoxedServerService. Restarting can not progress");
+
+                trace!(
+                    "Service {:?} has been restarted",
+                    self.factories[idx].name(token)
+                );
+
+                self.services[token.0].created(service);
+                self.state = WorkerState::Unavailable;
+
                 self.poll(cx)
             }
             WorkerState::Shutdown(ref mut t1, ref mut t2, ref mut tx) => {


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Refactor `WorkerState::Restarting`. 
Make service restart error panic a lazy unwrap. 
Panic when no `BoxServerService` given.(This should not happen as the returned service is explicitly made into a vec with https://github.com/actix/actix-net/blob/6d66cfb06a6541674e5dc19897bf0e2e7b6bc3cf/actix-server/src/service.rs#L138).

Remove the homebrew `ready` and `Ready` types from actix-server and use the ones from actix-utils.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
