### PR TITLE
Do not do double check on connection num when entering graceful shutdown

### DIFF
--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -356,18 +356,12 @@ impl Future for ServerWorker {
                 return Poll::Ready(());
             } else if graceful {
                 self.shutdown(false);
-                let num = num_connections();
-                if num != 0 {
-                    info!("Graceful worker shutdown, {} connections", num);
-                    self.state = WorkerState::Shutdown(
-                        Box::pin(sleep(Duration::from_secs(1))),
-                        Box::pin(sleep(self.config.shutdown_timeout)),
-                        Some(result),
-                    );
-                } else {
-                    let _ = result.send(true);
-                    return Poll::Ready(());
-                }
+                info!("Graceful worker shutdown, {} connections", num);
+                self.state = WorkerState::Shutdown(
+                    Box::pin(sleep(Duration::from_secs(1))),
+                    Box::pin(sleep(self.config.shutdown_timeout)),
+                    Some(result),
+                );
             } else {
                 info!("Force shutdown worker, {} connections", num);
                 self.shutdown(true);


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor 


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Double checko on `connection_num` is not necessary when entering graceful shutdown.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
