### PR TITLE
Fix bug where worker service restart could skip failing services and not being able to restart multiple services

### DIFF
--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -283,7 +283,6 @@ impl ServerWorker {
 
     fn check_readiness(&mut self, cx: &mut Context<'_>) -> Result<bool, (Token, usize)> {
         let mut ready = self.conns.available(cx);
-        let mut failed = None;
         for (idx, srv) in self.services.iter_mut().enumerate() {
             if srv.status == WorkerServiceStatus::Available
                 || srv.status == WorkerServiceStatus::Unavailable
@@ -314,17 +313,14 @@ impl ServerWorker {
                             "Service {:?} readiness check returned error, restarting",
                             self.factories[srv.factory].name(Token(idx))
                         );
-                        failed = Some((Token(idx), srv.factory));
                         srv.status = WorkerServiceStatus::Failed;
+                        return Err((Token(idx), srv.factory));
                     }
                 }
             }
         }
-        if let Some(idx) = failed {
-            Err(idx)
-        } else {
-            Ok(ready)
-        }
+
+        Ok(ready)
     }
 }
 

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -404,18 +404,16 @@ impl Future for ServerWorker {
                 let factory_id = restart.factory_id;
                 let token = restart.token;
 
-                let item = ready!(restart.fut.as_mut().poll(cx)).unwrap_or_else(|_| {
+                let mut item = ready!(restart.fut.as_mut().poll(cx)).unwrap_or_else(|_| {
                     panic!(
                         "Can not restart {:?} service",
                         this.factories[factory_id].name(token)
                     )
                 });
 
-                // Only interest in the first item?
-                let (token, service) = item
-                    .into_iter()
-                    .next()
-                    .expect("No BoxedServerService. Restarting can not progress");
+                // Token should have a matching index with returned item vec.
+                debug_assert_eq!(item.get(token.0).unwrap().0, token);
+                let (token, service) = item.remove(token.0);
 
                 trace!(
                     "Service {:?} has been restarted",


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
When worker restarting multiple services that return error from `Service::poll_ready` the current logic would be throwing away all error except the last one in iteration. As previous service states are set to `WorkerServiceStatus::Failed` which would skip future readiness check and render they skip `poll_ready` check from then on.

When multiple services are started with `ServerBuilder::configure` API the factory service future would return a vec of `(Token, BoxedServerService)` type. And the restart logic would always take the first element from the vec. Making there is no way to restart any service other than the first one registered to `configure`.

This PR fixes these two bug with properly handle every error returned with `Service::poll_ready` and not skip to next untill the last one is resolved. After the service restart the `Token` of restarting service would be used to get the correct element in returned vector instead of only using the first one.



<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
