### PR TITLE
add spsc channel

### DIFF
--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -17,18 +17,17 @@ edition = "2018"
 name = "actix_server"
 path = "src/lib.rs"
 
-[features]
-default = []
-
 [dependencies]
 actix-rt = { version = "2.0.0", default-features = false }
 actix-service = "2.0.0-beta.5"
 actix-utils = "3.0.0-beta.4"
 
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.7", default-features = false }
 log = "0.4"
-mio = { version = "0.7.6", features = ["os-poll", "net"] }
+mio = { version = "0.7.11", features = ["os-poll", "net", "os-util"] }
 num_cpus = "1.13"
+rtrb = ""
 slab = "0.4"
 tokio = { version = "1.2", features = ["sync"] }
 

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -23,11 +23,10 @@ actix-service = "2.0.0-beta.5"
 actix-utils = "3.0.0-beta.4"
 
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
-futures-util = { version = "0.3.7", default-features = false }
 log = "0.4"
-mio = { version = "0.7.11", features = ["os-poll", "net", "os-util"] }
+mio = { version = "0.7.11", features = ["os-poll", "net"] }
 num_cpus = "1.13"
-rtrb = ""
+rtrb = "0.1"
 slab = "0.4"
 tokio = { version = "1.2", features = ["sync"] }
 

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -408,9 +408,7 @@ impl Accept {
 
     fn accept(&mut self, sockets: &mut Slab<ServerSocketInfo>, token: usize) {
         loop {
-            let info = sockets
-                .get_mut(token)
-                .expect("ServerSocketInfo is removed from Slab");
+            let info = &mut sockets[token];
 
             match info.lst.accept() {
                 Ok(io) => {

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -323,7 +323,7 @@ impl ServerBuilder {
         let avail = WorkerAvailability::new(waker);
         let services = self.services.iter().map(|v| v.clone_factory()).collect();
 
-        ServerWorker::start(idx, services, avail, self.worker_config)
+        ServerWorker::start(idx, self.backlog, services, avail, self.worker_config)
     }
 
     fn handle_cmd(&mut self, item: ServerCommand) {
@@ -384,7 +384,7 @@ impl ServerBuilder {
                 if !self.handles.is_empty() && graceful {
                     let iter = self
                         .handles
-                        .iter()
+                        .iter_mut()
                         .map(move |worker| worker.1.stop(graceful))
                         .collect();
 

--- a/actix-server/src/lib.rs
+++ b/actix-server/src/lib.rs
@@ -11,6 +11,7 @@ mod server;
 mod service;
 mod signals;
 mod socket;
+mod spsc;
 mod test_server;
 mod waker_queue;
 mod worker;

--- a/actix-server/src/socket.rs
+++ b/actix-server/src/socket.rs
@@ -13,7 +13,6 @@ use std::{fmt, io};
 
 use actix_rt::net::TcpStream;
 use mio::event::Source;
-use mio::net::TcpStream as MioTcpStream;
 use mio::{Interest, Registry, Token};
 
 #[cfg(windows)]
@@ -21,7 +20,6 @@ use std::os::windows::io::{FromRawSocket, IntoRawSocket};
 #[cfg(unix)]
 use {
     actix_rt::net::UnixStream,
-    mio::net::{SocketAddr as MioSocketAddr, UnixStream as MioUnixStream},
     std::os::unix::io::{FromRawFd, IntoRawFd},
 };
 
@@ -131,7 +129,7 @@ impl fmt::Display for MioListener {
 pub(crate) enum SocketAddr {
     Tcp(StdSocketAddr),
     #[cfg(unix)]
-    Uds(MioSocketAddr),
+    Uds(mio::net::SocketAddr),
 }
 
 impl fmt::Display for SocketAddr {
@@ -156,9 +154,9 @@ impl fmt::Debug for SocketAddr {
 
 #[derive(Debug)]
 pub enum MioStream {
-    Tcp(MioTcpStream),
+    Tcp(mio::net::TcpStream),
     #[cfg(unix)]
-    Uds(MioUnixStream),
+    Uds(mio::net::UnixStream),
 }
 
 /// helper trait for converting mio stream to tokio stream.

--- a/actix-server/src/spsc.rs
+++ b/actix-server/src/spsc.rs
@@ -1,0 +1,54 @@
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures_util::task::AtomicWaker;
+use rtrb::{Consumer, Producer, PushError, RingBuffer};
+
+pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
+    let (tx, rx) = RingBuffer::new(cap).split();
+    let waker = Arc::new(AtomicWaker::new());
+    let sender = Sender {
+        tx,
+        waker: waker.clone(),
+    };
+
+    let receiver = Receiver { rx, waker };
+
+    (sender, receiver)
+}
+
+pub struct Sender<T> {
+    tx: Producer<T>,
+    waker: Arc<AtomicWaker>,
+}
+
+impl<T> Sender<T> {
+    pub fn send(&mut self, item: T) -> Result<(), T> {
+        match self.tx.push(item) {
+            Ok(_) => {
+                self.waker.wake();
+                Ok(())
+            }
+            Err(PushError::Full(item)) => Err(item),
+        }
+    }
+}
+
+pub struct Receiver<T> {
+    rx: Consumer<T>,
+    waker: Arc<AtomicWaker>,
+}
+
+impl<T> Receiver<T> {
+    pub fn poll_recv_unpin(&mut self, cx: &mut Context<'_>) -> Poll<T> {
+        match self.rx.pop() {
+            Ok(item) => Poll::Ready(item),
+            Err(_) => {
+                self.waker.register(cx.waker());
+                Poll::Pending
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Use spsc channel for dispatch message from Accetp/ServerBuilder to workers. This would improve performance on accepting connections in general. But it's only impactful when managing short lived connections.(no keep-alive)

That said there is also a trade off to this change. One additional dep have been introduced and only used in actix-server.

Example bench code:
```rust
use std::io;

use actix_rt::net::TcpStream;
use actix_server::Server;
use actix_service::fn_service;
use tokio::io::AsyncWriteExt;

const BUF: &[u8] =
    b"HTTP/1.1 200 OK\r\n\
    content-length: 12\r\n\
    connection: close\r\n\
    date: Thu, 01 Jan 1970 12:34:56 UTC\r\n\
    \r\n\
    Hello World!\
    ";

fn main() -> io::Result<()> {
    let name = "short_life";
    let addr = "127.0.0.1:8080";

    actix_rt::System::new().block_on(async {
        Server::build()
            .bind(name, addr, || fn_service(response))?
            .run()
            .await
    })
}

async fn response(mut stream: TcpStream) -> io::Result<()> {
    stream.write(BUF).await?;
    stream.flush().await?;
    stream.shutdown().await
}
```

Benchmark tool and config:
`./wrk -t12 -c512 -d10 http://localhost:8080/`

Sample result(Result could be vary from run to run and differ on different system/metal):
```
refactor/spsc branch:

  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.44ms    3.85ms  55.50ms   88.34%
    Req/Sec    13.45k     3.56k   25.58k    73.11%
  1609624 requests in 10.09s, 164.25MB read
Requests/sec: 159509.95
Transfer/sec:     16.28MB


actix-server = "2.0.0-beta.4":

  12 threads and 512 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.82ms    4.71ms  69.68ms   89.25%
    Req/Sec    13.28k     3.03k   24.04k    73.65%
  1586311 requests in 10.10s, 161.87MB read
Requests/sec: 157076.48
Transfer/sec:     16.03MB


actix-server = "1.0.4":

  12 threads and 512 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.00ms    4.10ms  51.04ms   86.92%
    Req/Sec    12.79k     2.46k   24.48k    73.30%
  1534088 requests in 10.09s, 156.54MB read
Requests/sec: 152010.34
Transfer/sec:     15.51MB
```
<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #320