### PR TITLE
Fix bug where backpressure happen too early

### DIFF
--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -119,7 +119,11 @@ impl Availability {
         if avail {
             self.0[offset] |= 1 << idx as u128;
         } else {
-            self.0[offset] ^= 1 << idx as u128;
+            let shift = 1 << idx as u128;
+
+            debug_assert_ne!(self.0[offset] & shift, 0);
+
+            self.0[offset] ^= shift;
         }
     }
 
@@ -519,6 +523,8 @@ mod test {
         aval.set_available(idx, true);
         assert!(aval.available());
 
+        aval.set_available(idx, true);
+
         aval.set_available(idx, false);
         assert!(!aval.available());
     }
@@ -557,6 +563,13 @@ mod test {
     fn overflow() {
         let mut aval = Availability::default();
         single(&mut aval, 512);
+    }
+
+    #[test]
+    #[should_panic]
+    fn double_set_unavailable() {
+        let mut aval = Availability::default();
+        aval.set_available(233, false);
     }
 
     #[test]

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -113,7 +113,7 @@ impl Availability {
         } else if idx < 128 * 4 {
             (3, idx - 128 * 3)
         } else {
-            unreachable!("Max WorkerHandle count is 512")
+            panic!("Max WorkerHandle count is 512")
         };
 
         if avail {


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
When accepting connections there was only one round trip for checking the availability state of workers from Accept.next to Accept.next + Accept.handles.len().
This would trigger backpressure early and force drain backlog to workers from the second round regardless their availability states.

This PR use [u128; 4] to track up to 512 worker handles' state and only enter backpressure when all of them goes into non available state.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #329 