### PR TITLE
Fix worker are notified to stop with non_graceful shutdown

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - 2021-xx-xx
 * Server shutdown would notify all workers to exit regardless if shutdown is graceful.
-  This would make all worker shutdown immediately [#333]
+  This would make all worker shutdown immediately in force shutdown case. [#333]
   
 [#333]: https://github.com/actix/actix-net/pull/333
 

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -1,6 +1,10 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Server shutdown would notify all workers to exit regardless if shutdown is graceful.
+  This would make all worker shutdown immediately [#333]
+  
+[#333]: https://github.com/actix/actix-net/pull/333
 
 
 ## 2.0.0-beta.4 - 2021-04-01


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
With non graceful shutdown there is no signal for notify worker threads to exit. This could result in leak of worker threads.

This PR changes to notify worker threads to shutdown on all cases. But only in graceful shutdown case server builer wait for worker shutdown response.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
