### PR TITLE
Fix Display impl of MioListener

### DIFF
--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -10,15 +10,12 @@ use mio::{Interest, Poll, Token as MioToken};
 use slab::Slab;
 
 use crate::server::Server;
-use crate::socket::{MioListener, SocketAddr};
+use crate::socket::MioListener;
 use crate::waker_queue::{WakerInterest, WakerQueue, WAKER_TOKEN};
 use crate::worker::{Conn, WorkerHandleAccept};
 use crate::Token;
 
 struct ServerSocketInfo {
-    /// Address of socket. Mainly used for logging.
-    addr: SocketAddr,
-
     /// Beware this is the crate token for identify socket and should not be confused
     /// with `mio::Token`.
     token: Token,
@@ -178,8 +175,6 @@ impl Accept {
     ) -> (Accept, Slab<ServerSocketInfo>) {
         let mut sockets = Slab::new();
         for (hnd_token, mut lst) in socks.into_iter() {
-            let addr = lst.local_addr();
-
             let entry = sockets.vacant_entry();
             let token = entry.key();
 
@@ -189,7 +184,6 @@ impl Accept {
                 .unwrap_or_else(|e| panic!("Can not register io: {}", e));
 
             entry.insert(ServerSocketInfo {
-                addr,
                 token: hnd_token,
                 lst,
                 timeout: None,
@@ -333,7 +327,7 @@ impl Accept {
 
     fn register_logged(&self, token: usize, info: &mut ServerSocketInfo) {
         match self.register(token, info) {
-            Ok(_) => info!("Resume accepting connections on {}", info.addr),
+            Ok(_) => info!("Resume accepting connections on {}", info.lst.local_addr()),
             Err(e) => error!("Can not register server socket {}", e),
         }
     }
@@ -344,7 +338,7 @@ impl Accept {
 
     fn deregister_logged(&self, info: &mut ServerSocketInfo) {
         match self.deregister(info) {
-            Ok(_) => info!("Paused accepting connections on {}", info.addr),
+            Ok(_) => info!("Paused accepting connections on {}", info.lst.local_addr()),
             Err(e) => {
                 error!("Can not deregister server socket {}", e)
             }

--- a/actix-server/src/socket.rs
+++ b/actix-server/src/socket.rs
@@ -23,9 +23,15 @@ pub(crate) enum MioListener {
 impl MioListener {
     pub(crate) fn local_addr(&self) -> SocketAddr {
         match *self {
-            MioListener::Tcp(ref lst) => SocketAddr::Tcp(lst.local_addr().unwrap()),
+            MioListener::Tcp(ref lst) => lst
+                .local_addr()
+                .map(SocketAddr::Tcp)
+                .unwrap_or(SocketAddr::Unknown),
             #[cfg(unix)]
-            MioListener::Uds(ref lst) => SocketAddr::Uds(lst.local_addr().unwrap()),
+            MioListener::Uds(ref lst) => lst
+                .local_addr()
+                .map(SocketAddr::Uds)
+                .unwrap_or(SocketAddr::Unknown),
         }
     }
 
@@ -110,14 +116,15 @@ impl fmt::Debug for MioListener {
 impl fmt::Display for MioListener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            MioListener::Tcp(ref lst) => write!(f, "{}", lst.local_addr().ok().unwrap()),
+            MioListener::Tcp(ref lst) => write!(f, "{:?}", lst),
             #[cfg(unix)]
-            MioListener::Uds(ref lst) => write!(f, "{:?}", lst.local_addr().ok().unwrap()),
+            MioListener::Uds(ref lst) => write!(f, "{:?}", lst),
         }
     }
 }
 
 pub(crate) enum SocketAddr {
+    Unknown,
     Tcp(StdSocketAddr),
     #[cfg(unix)]
     Uds(mio::net::SocketAddr),
@@ -126,9 +133,10 @@ pub(crate) enum SocketAddr {
 impl fmt::Display for SocketAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            SocketAddr::Tcp(ref addr) => write!(f, "{}", addr),
+            Self::Unknown => write!(f, "Unknown SocketAddr"),
+            Self::Tcp(ref addr) => write!(f, "{}", addr),
             #[cfg(unix)]
-            SocketAddr::Uds(ref addr) => write!(f, "{:?}", addr),
+            Self::Uds(ref addr) => write!(f, "{:?}", addr),
         }
     }
 }
@@ -136,9 +144,10 @@ impl fmt::Display for SocketAddr {
 impl fmt::Debug for SocketAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            SocketAddr::Tcp(ref addr) => write!(f, "{:?}", addr),
+            Self::Unknown => write!(f, "Unknown SocketAddr"),
+            Self::Tcp(ref addr) => write!(f, "{:?}", addr),
             #[cfg(unix)]
-            SocketAddr::Uds(ref addr) => write!(f, "{:?}", addr),
+            Self::Uds(ref addr) => write!(f, "{:?}", addr),
         }
     }
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Fix Display of `MioListener`. It would display both addr and fd.

Remove `SocketAddr` field from `ServerSocketInfo`. Reduce the size by more than 100 bytes.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
