### PR TITLE
Fix interrupt handling. Fix double server pause/resume

### DIFF
--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -223,7 +223,7 @@ impl Accept {
         loop {
             if let Err(e) = self.poll.poll(&mut events, None) {
                 match e.kind() {
-                    io::ErrorKind::Interrupted => continue,
+                    io::ErrorKind::Interrupted => {}
                     _ => panic!("Poll error: {}", e),
                 }
             }
@@ -286,23 +286,29 @@ impl Accept {
                 Some(WakerInterest::Pause) => {
                     drop(guard);
 
-                    self.paused = true;
+                    if !self.paused {
+                        self.paused = true;
 
-                    self.deregister_all(sockets);
+                        self.deregister_all(sockets);
+                    }
                 }
                 Some(WakerInterest::Resume) => {
                     drop(guard);
 
-                    self.paused = false;
+                    if self.paused {
+                        self.paused = false;
 
-                    sockets.iter_mut().for_each(|info| {
-                        self.register_logged(info);
-                    });
+                        sockets.iter_mut().for_each(|info| {
+                            self.register_logged(info);
+                        });
 
-                    self.accept_all(sockets);
+                        self.accept_all(sockets);
+                    }
                 }
                 Some(WakerInterest::Stop) => {
-                    self.deregister_all(sockets);
+                    if !self.paused {
+                        self.deregister_all(sockets);
+                    }
 
                     return true;
                 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
actix-server does not check current state when `WakerInterest` comes in. This result in it would keep (de)register sockets when interests like pause/resume/stop comes in. This PR check the pause state of Accept on receiving these interests to prevent double (de)register.

mio poll on interrupt error could already contains events that ready to read. Instead of continue we should check events to make sure.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
