### PR TITLE
Docs: Fix signature of Service::call

### DIFF
--- a/actix-service/src/transform.rs
+++ b/actix-service/src/transform.rs
@@ -41,7 +41,7 @@ where
 ///
 ///     actix_service::forward_ready!(service);
 ///
-///     fn call(&self, req: S::Request) -> Self::Future {
+///     fn call(&self, req: Req) -> Self::Future {
 ///         TimeoutServiceResponse {
 ///             fut: self.service.call(req),
 ///             sleep: Sleep::new(clock::now() + self.timeout),


### PR DESCRIPTION
## PR Type

Other / Docs

## Overview

The current docs contain a wrong method signature for `Service::call`. The `Service` trait does not have a `Request` associated type anymore.

(Note: The example is currently marked as ignored. It would be good if this example code would be tested, to avoid future breakage. I tried to come up with the required boilerplate for the timeout example, but failed. Maybe a more simple middleware example could be picked?)