### PR TITLE
`Path`: fix unsafe malformed string

### DIFF
--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased - 2021-xx-xx
 * When matching URL parameters, `%25` is kept in the percent-encoded form - no longer decoded to `%`. [#357]
+* Fixed a bug where the `Path` extractor returns unsafe malformed string due to malformed URL. [#359]
 
 [#357]: https://github.com/actix/actix-net/pull/357
+[#359]: https://github.com/actix/actix-net/pull/359
 
 
 ## 0.2.7 - 2021-02-06

--- a/actix-router/src/url.rs
+++ b/actix-router/src/url.rs
@@ -260,6 +260,16 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_utf8() {
+        let invalid_utf8 = percent_encode((0x80..=0xff).collect::<Vec<_>>().as_slice());
+        let uri = Uri::try_from(format!("/{}", invalid_utf8)).unwrap();
+        let path = Path::new(Url::new(uri));
+
+        // We should always get a valid utf8 string
+        assert!(String::from_utf8(path.path().as_bytes().to_owned()).is_ok());
+    }
+
+    #[test]
     fn test_from_hex() {
         let hex = b"0123456789abcdefABCDEF";
 

--- a/actix-router/src/url.rs
+++ b/actix-router/src/url.rs
@@ -170,11 +170,7 @@ impl Quoter {
             idx += 1;
         }
 
-        cloned.map(|data| {
-            // SAFETY: we get data from http::Uri, which does UTF-8 checks already
-            // this code only decodes valid pct encoded values
-            unsafe { String::from_utf8_unchecked(data) }
-        })
+        cloned.map(|data| String::from_utf8_lossy(&data).into_owned())
     }
 }
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`String::from_utf8_unchecked()` is used unsafely here - the user is allowed by the standards to encode any binary data in URL by percent-encoding.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
