### PR TITLE
router: handle newline char '\n' in url

### DIFF
--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -4,10 +4,12 @@
 * `Path::add` and `add_static` takes `impl Into<Cow<'static, str>>` [#345]
 * When matching URL parameters, `%25` is kept in the percent-encoded form - no longer decoded to `%`. [#357]
 * Fixed a bug where the `Path` extractor returns unsafe malformed string due to malformed URL. [#359]
+* Path tail patterns now match `'\n'` in request URL. [#360]
 
 [#345]: https://github.com/actix/actix-net/pull/345
 [#357]: https://github.com/actix/actix-net/pull/357
 [#359]: https://github.com/actix/actix-net/pull/359
+[#360]: https://github.com/actix/actix-net/pull/360
 
 
 ## 0.2.7 - 2021-02-06

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -817,6 +817,32 @@ mod tests {
         assert!(re.is_match("/user/2345/sdg"));
     }
 
+    #[test]
+    fn test_newline() {
+        let re = ResourceDef::new("/user/a\nb");
+        assert!(re.is_match("/user/a\nb"));
+        assert!(!re.is_match("/user/a\nb/profile"));
+
+        let re = ResourceDef::new("/a{x}b/test/a{y}b");
+        let mut path = Path::new("/a\nb/test/a\nb");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.get("x").unwrap(), "\n");
+        assert_eq!(path.get("y").unwrap(), "\n");
+
+        let re = ResourceDef::new("/user/*");
+        assert!(re.is_match("/user/a\nb/"));
+
+        let re = ResourceDef::new("/user/{id}*");
+        let mut path = Path::new("/user/a\nb/a\nb");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.get("id").unwrap(), "a\nb/a\nb");
+
+        let re = ResourceDef::new("/user/{id:.*}");
+        let mut path = Path::new("/user/a\nb/a\nb");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.get("id").unwrap(), "a\nb/a\nb");
+    }
+
     #[cfg(feature = "http")]
     #[test]
     fn test_parse_urlencoded_param() {

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -10,6 +10,8 @@ use crate::{IntoPattern, Resource, ResourcePath};
 
 const MAX_DYNAMIC_SEGMENTS: usize = 16;
 
+const REGEX_FLAGS: &str = "(?s-m)";
+
 /// ResourceDef describes an entry in resources table
 ///
 /// Resource definition can contain only 16 dynamic segments
@@ -571,7 +573,7 @@ impl ResourceDef {
     ) -> (String, Vec<PatternElement>, bool, usize) {
         if pattern.find('{').is_none() {
             return if let Some(path) = pattern.strip_suffix('*') {
-                let re = String::from("^") + path + "(.*)";
+                let re = format!("{}^{}(.*)", REGEX_FLAGS, path);
                 (re, vec![PatternElement::Str(String::from(path))], true, 0)
             } else {
                 (
@@ -584,7 +586,7 @@ impl ResourceDef {
         }
 
         let mut elements = Vec::new();
-        let mut re = String::from("^");
+        let mut re = format!("{}^", REGEX_FLAGS);
         let mut dyn_elements = 0;
 
         while let Some(idx) = pattern.find('{') {

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -10,6 +10,9 @@ use crate::{IntoPattern, Resource, ResourcePath};
 
 const MAX_DYNAMIC_SEGMENTS: usize = 16;
 
+/// Regex flags to allow '.' in regex to match '\n'
+///
+/// See the docs under: https://docs.rs/regex/1.5.4/regex/#grouping-and-flags
 const REGEX_FLAGS: &str = "(?s-m)";
 
 /// ResourceDef describes an entry in resources table


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
A `Path` instance may contain newline chars (`\n`) in the path segments. In such case, tests have shown some problems when matching URL parameters (specifically, path tail patterns; see the test case!)  . This turned out to be because in `regex`, `.` doesn't match `\n` by default.

The solution is to either keep newline chars in percent encoding (`%0A`) or to use regex flags to get the desired behavior. I tried to implement the latter.
<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
