### PR TITLE
router: fix multi-pattern and path tail matches

### DIFF
--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -2,8 +2,11 @@
 
 ## Unreleased - 2021-xx-xx
 * Fix segment interpolation leaving `Path` in unintended state after matching. [#368]
+* Path tail pattern now works as expected after a dynamic segment (e.g. `/user/{uid}/*`). [#366]
+* Fixed a bug where, in multi-patterns, static patterns are interpreted as regex. [#366]
 
 [#368]: https://github.com/actix/actix-net/pull/368
+[#366]: https://github.com/actix/actix-net/pull/366
 
 
 ## 0.4.0 - 2021-06-06

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -571,6 +571,7 @@ mod tests {
             "/user/{id}",
             "/v{version}/resource/{id}",
             "/{id:[[:digit:]]{6}}",
+            "/static",
         ]);
         assert!(re.is_match("/user/profile"));
         assert!(re.is_match("/user/2345"));
@@ -600,6 +601,10 @@ mod tests {
         assert!(!re.is_match("/012"));
         assert!(!re.is_match("/01234567"));
         assert!(!re.is_match("/XXXXXX"));
+
+        assert!(re.is_match("/static"));
+        assert!(!re.is_match("/a/static"));
+        assert!(!re.is_match("/static/a"));
 
         let mut path = Path::new("/012345");
         assert!(re.match_path(&mut path));
@@ -660,6 +665,12 @@ mod tests {
         assert!(re.is_match("/user/2345"));
         assert!(re.is_match("/user/2345/"));
         assert!(re.is_match("/user/2345/sdg"));
+
+        let re = ResourceDef::new("/user/{id}/*");
+        assert!(!re.is_match("/user/2345"));
+        let mut path = Path::new("/user/2345/sdg");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.get("id").unwrap(), "2345");
     }
 
     #[test]

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -48,29 +48,19 @@ impl ResourceDef {
     /// Panics if path pattern is malformed.
     pub fn new<T: IntoPattern>(path: T) -> Self {
         if path.is_single() {
-            let patterns = path.patterns();
-            ResourceDef::with_prefix(&patterns[0], false)
+            ResourceDef::from_single_pattern(&path.patterns()[0], false)
         } else {
-            let set = path.patterns();
             let mut data = Vec::new();
             let mut re_set = Vec::new();
 
-            for path in set {
-                let (pattern, _, _) = ResourceDef::parse(&path, false, true);
-
-                let re = match Regex::new(&pattern) {
-                    Ok(re) => re,
-                    Err(err) => panic!("Wrong path pattern: \"{}\" {}", path, err),
-                };
-                // actix creates one router per thread
-                let names: Vec<_> = re
-                    .capture_names()
-                    .filter_map(|name| {
-                        name.map(|name| Box::leak(Box::new(name.to_owned())).as_str())
-                    })
-                    .collect();
-                data.push((re, names));
-                re_set.push(pattern);
+            for pattern in path.patterns() {
+                match ResourceDef::parse(&pattern, false, true) {
+                    (PatternType::Dynamic(re, names), _) => {
+                        re_set.push(re.as_str().to_owned());
+                        data.push((re, names));
+                    }
+                    _ => unreachable!(),
+                }
             }
 
             ResourceDef {
@@ -89,7 +79,7 @@ impl ResourceDef {
     ///
     /// Panics if path regex pattern is malformed.
     pub fn prefix(path: &str) -> Self {
-        ResourceDef::with_prefix(path, true)
+        ResourceDef::from_single_pattern(path, true)
     }
 
     /// Parse path pattern and create new `Pattern` instance.
@@ -100,7 +90,7 @@ impl ResourceDef {
     ///
     /// Panics if path regex pattern is malformed.
     pub fn root_prefix(path: &str) -> Self {
-        ResourceDef::with_prefix(&insert_slash(path), true)
+        ResourceDef::from_single_pattern(&insert_slash(path), true)
     }
 
     /// Resource id
@@ -113,36 +103,17 @@ impl ResourceDef {
         self.id = id;
     }
 
-    /// Parse path pattern and create new `Pattern` instance with custom prefix
-    fn with_prefix(path: &str, for_prefix: bool) -> Self {
-        let path = path.to_owned();
-        let (pattern, elements, is_dynamic) = ResourceDef::parse(&path, for_prefix, false);
-
-        let tp = if is_dynamic {
-            let re = match Regex::new(&pattern) {
-                Ok(re) => re,
-                Err(err) => panic!("Wrong path pattern: \"{}\" {}", path, err),
-            };
-            // actix creates one router per thread
-            let names = re
-                .capture_names()
-                .filter_map(|name| {
-                    name.map(|name| Box::leak(Box::new(name.to_owned())).as_str())
-                })
-                .collect();
-            PatternType::Dynamic(re, names)
-        } else if for_prefix {
-            PatternType::Prefix(pattern)
-        } else {
-            PatternType::Static(pattern)
-        };
+    /// Parse path pattern and create a new instance
+    fn from_single_pattern(pattern: &str, for_prefix: bool) -> Self {
+        let pattern = pattern.to_owned();
+        let (tp, elements) = ResourceDef::parse(&pattern, for_prefix, false);
 
         ResourceDef {
             tp,
             elements: Some(elements),
             id: 0,
             name: String::new(),
-            pattern: path,
+            pattern: pattern.to_string(),
         }
     }
 
@@ -404,15 +375,17 @@ impl ResourceDef {
         mut pattern: &str,
         mut for_prefix: bool,
         force_dynamic: bool,
-    ) -> (String, Vec<PatternElement>, bool) {
+    ) -> (PatternType, Vec<PatternElement>) {
         if !force_dynamic && pattern.find('{').is_none() && !pattern.ends_with('*') {
-            return (
-                String::from(pattern),
-                vec![PatternElement::Const(String::from(pattern))],
-                false,
-            );
+            let tp = if for_prefix {
+                PatternType::Prefix(String::from(pattern))
+            } else {
+                PatternType::Static(String::from(pattern))
+            };
+            return (tp, vec![PatternElement::Const(String::from(pattern))]);
         }
 
+        let pattern_orig = pattern.to_owned();
         let mut elements = Vec::new();
         let mut re = format!("{}^", REGEX_FLAGS);
         let mut dyn_elements = 0;
@@ -452,7 +425,18 @@ impl ResourceDef {
         if !for_prefix {
             re.push('$');
         }
-        (re, elements, true)
+
+        let re = match Regex::new(&re) {
+            Ok(re) => re,
+            Err(err) => panic!("Wrong path pattern: \"{}\" {}", pattern_orig, err),
+        };
+        // actix creates one router per thread
+        let names = re
+            .capture_names()
+            .filter_map(|name| name.map(|name| Box::leak(Box::new(name.to_owned())).as_str()))
+            .collect();
+
+        (PatternType::Dynamic(re, names), elements)
     }
 }
 

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -110,10 +110,10 @@ impl ResourceDef {
 
         ResourceDef {
             tp,
+            pattern,
             elements: Some(elements),
             id: 0,
             name: String::new(),
-            pattern: pattern.to_string(),
         }
     }
 
@@ -385,7 +385,7 @@ impl ResourceDef {
             return (tp, vec![PatternElement::Const(String::from(pattern))]);
         }
 
-        let pattern_orig = pattern.to_owned();
+        let pattern_orig = pattern;
         let mut elements = Vec::new();
         let mut re = format!("{}^", REGEX_FLAGS);
         let mut dyn_elements = 0;


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
In muti-pattern, static patterns are accidentaly interpreted as regex. This is fixed by adding a flag to `parse()` (`force_dynamic`) to force it to always escape and render the pattern as regex even when it is static.

This also fixes the case when _static_ path tail (`/*`) is used after a dynamic segment:

>  `/static/*` ... already works
> `/{user}*` ... already works; stores the path tail in `user`
> `/{user}/*` ... doesn't work as expected.

Please see failing tests and linked issue.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes actix/actix-web#1647