### PR TITLE
`path.len()` != `path.path().len()`

### DIFF
--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Fix segment interpolation leaving `Path` in unintended state after matching. [#368]
+
+[#368]: https://github.com/actix/actix-net/pull/368
 
 
 ## 0.4.0 - 2021-06-06

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -235,7 +235,7 @@ impl ResourceDef {
                 if s != path.path() {
                     return false;
                 }
-                (path.len(), None)
+                (path.path().len(), None)
             }
             PatternType::Prefix(ref s) => {
                 let len = {
@@ -254,7 +254,7 @@ impl ResourceDef {
                         return false;
                     }
                 };
-                (min(path.len(), len), None)
+                (min(path.path().len(), len), None)
             }
             PatternType::Dynamic(ref re, ref names) => {
                 let captures = match re.captures(path.path()) {

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -674,6 +674,10 @@ mod tests {
         assert!(!re.is_match("/name/"));
         assert!(!re.is_match("/name~"));
 
+        let mut path = Path::new("/name");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.unprocessed(), "");
+
         assert_eq!(re.is_prefix_match("/name"), Some(5));
         assert_eq!(re.is_prefix_match("/name1"), None);
         assert_eq!(re.is_prefix_match("/name/"), None);
@@ -687,6 +691,10 @@ mod tests {
         let re = ResourceDef::new("/user/profile");
         assert!(re.is_match("/user/profile"));
         assert!(!re.is_match("/user/profile/profile"));
+
+        let mut path = Path::new("/user/profile");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.unprocessed(), "");
     }
 
     #[test]
@@ -700,10 +708,12 @@ mod tests {
         let mut path = Path::new("/user/profile");
         assert!(re.match_path(&mut path));
         assert_eq!(path.get("id").unwrap(), "profile");
+        assert_eq!(path.unprocessed(), "");
 
         let mut path = Path::new("/user/1245125");
         assert!(re.match_path(&mut path));
         assert_eq!(path.get("id").unwrap(), "1245125");
+        assert_eq!(path.unprocessed(), "");
 
         let re = ResourceDef::new("/v{version}/resource/{id}");
         assert!(re.is_match("/v1/resource/320120"));
@@ -714,6 +724,7 @@ mod tests {
         assert!(re.match_path(&mut path));
         assert_eq!(path.get("version").unwrap(), "151");
         assert_eq!(path.get("id").unwrap(), "adage32");
+        assert_eq!(path.unprocessed(), "");
 
         let re = ResourceDef::new("/{id:[[:digit:]]{6}}");
         assert!(re.is_match("/012345"));
@@ -724,6 +735,7 @@ mod tests {
         let mut path = Path::new("/012345");
         assert!(re.match_path(&mut path));
         assert_eq!(path.get("id").unwrap(), "012345");
+        assert_eq!(path.unprocessed(), "");
     }
 
     #[allow(clippy::cognitive_complexity)]
@@ -742,10 +754,12 @@ mod tests {
         let mut path = Path::new("/user/profile");
         assert!(re.match_path(&mut path));
         assert_eq!(path.get("id").unwrap(), "profile");
+        assert_eq!(path.unprocessed(), "");
 
         let mut path = Path::new("/user/1245125");
         assert!(re.match_path(&mut path));
         assert_eq!(path.get("id").unwrap(), "1245125");
+        assert_eq!(path.unprocessed(), "");
 
         assert!(re.is_match("/v1/resource/320120"));
         assert!(!re.is_match("/v/resource/1"));
@@ -878,6 +892,14 @@ mod tests {
         assert!(re.is_match("/name1"));
         assert!(re.is_match("/name~"));
 
+        let mut path = Path::new("/name");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.unprocessed(), "");
+
+        let mut path = Path::new("/name/test");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.unprocessed(), "/test");
+
         assert_eq!(re.is_prefix_match("/name"), Some(5));
         assert_eq!(re.is_prefix_match("/name/"), Some(5));
         assert_eq!(re.is_prefix_match("/name/test/test"), Some(5));
@@ -893,6 +915,10 @@ mod tests {
         assert!(re.is_match("/name/"));
         assert!(re.is_match("/name/gs"));
         assert!(!re.is_match("/name"));
+
+        let mut path = Path::new("/name/gs");
+        assert!(re.match_path(&mut path));
+        assert_eq!(path.unprocessed(), "/gs");
     }
 
     #[test]
@@ -910,11 +936,13 @@ mod tests {
         assert!(re.match_path(&mut path));
         assert_eq!(&path["name"], "test2");
         assert_eq!(&path[0], "test2");
+        assert_eq!(path.unprocessed(), "");
 
         let mut path = Path::new("/test2/subpath1/subpath2/index.html");
         assert!(re.match_path(&mut path));
         assert_eq!(&path["name"], "test2");
         assert_eq!(&path[0], "test2");
+        assert_eq!(path.unprocessed(), "subpath1/subpath2/index.html");
     }
 
     #[test]

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -252,7 +252,7 @@ impl ResourceDef {
         match self.tp {
             PatternType::Static(ref s) => {
                 if s == path.path() {
-                    path.skip(path.len() as u16);
+                    path.skip(path.path().len() as u16);
                     true
                 } else {
                     false
@@ -354,7 +354,7 @@ impl ResourceDef {
             PatternType::Static(ref s) => {
                 if s == res.resource_path().path() && check(res, user_data) {
                     let path = res.resource_path();
-                    path.skip(path.len() as u16);
+                    path.skip(path.path().len() as u16);
                     true
                 } else {
                     false


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`Path::len()` has a very confusing name! 

This bug leaves the `Path` in  unintended  state after matching. It only applies to static non-prefix matches, which is always the last pattern to match. So, it doesn't have much of impact (except for users of `HttpRequest::match_info()` for actix-web). However, it caused more problems for me in #365 .

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
