### PR TITLE
allow path building when resource has tail

### DIFF
--- a/actix-router/CHANGES.md
+++ b/actix-router/CHANGES.md
@@ -1,15 +1,20 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Resource definitions with unnamed tail segments now correctly interpolate the tail when constructed from an iterator. [#371]
+* Introduce `ResourceDef::resource_path_from_map_with_tail` method to allow building paths in the presence of unnamed tail segments. [#371]
 * Fix segment interpolation leaving `Path` in unintended state after matching. [#368]
 * Path tail pattern now works as expected after a dynamic segment (e.g. `/user/{uid}/*`). [#366]
 * Fixed a bug where, in multi-patterns, static patterns are interpreted as regex. [#366]
 * Rename `Path::{len => segment_count}` to be more descriptive of it's purpose. [#370]
+* Alias `ResourceDef::{resource_path => resource_path_from_iter}` pending eventual deprecation. [#371]
+* Alias `ResourceDef::{resource_path_named => resource_path_from_map}` pending eventual deprecation. [#371]
 
 [#368]: https://github.com/actix/actix-net/pull/368
 [#366]: https://github.com/actix/actix-net/pull/366
 [#368]: https://github.com/actix/actix-net/pull/368
 [#370]: https://github.com/actix/actix-net/pull/370
+[#371]: https://github.com/actix/actix-net/pull/371
 
 
 ## 0.4.0 - 2021-06-06

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -448,7 +448,7 @@ impl ResourceDef {
         })
     }
 
-    fn parse_param(pattern: &str) -> (PatternElement, String, &str, bool) {
+    fn parse_param(pattern: &str) -> (PatternElement, String, &str) {
         const DEFAULT_PATTERN: &str = "[^/]+";
         const DEFAULT_PATTERN_TAIL: &str = ".*";
 
@@ -502,7 +502,7 @@ impl ResourceDef {
 
         let regex = format!(r"(?P<{}>{})", &name, &pattern);
 
-        (element, regex, unprocessed, tail)
+        (element, regex, unprocessed)
     }
 
     fn parse(
@@ -532,9 +532,9 @@ impl ResourceDef {
             elements.push(PatternElement::Const(prefix.to_owned()));
             re.push_str(&escape(prefix));
 
-            let (param_pattern, re_part, rem, tail) = Self::parse_param(rem);
+            let (param_pattern, re_part, rem) = Self::parse_param(rem);
 
-            if tail {
+            if matches!(param_pattern, PatternElement::Tail(_)) {
                 has_tail_segment = true;
             }
 
@@ -556,7 +556,7 @@ impl ResourceDef {
 
             dyn_elements += 1;
         } else if !has_tail_segment {
-            // prevent `Const("")` element from being added after dynamic segments
+            // prevent `Const("")` element from being added after tail segments
 
             elements.push(PatternElement::Const(pattern.to_owned()));
             re.push_str(&escape(pattern));

--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -559,7 +559,7 @@ impl ResourceDef {
 
             dyn_elements += 1;
         } else if !has_tail_segment && !unprocessed.is_empty() {
-            // prevent `Const("")` element from being added after tail segment
+            // prevent `Const("")` element from being added after last dynamic segment
 
             elements.push(PatternElement::Const(unprocessed.to_owned()));
             re.push_str(&escape(unprocessed));
@@ -875,7 +875,6 @@ mod tests {
     #[test]
     fn prefix_static() {
         let re = ResourceDef::prefix("/name");
-        println!("{:#?}", &re);
 
         assert!(re.is_match("/name"));
         assert!(re.is_match("/name/"));
@@ -914,11 +913,7 @@ mod tests {
 
     #[test]
     fn prefix_dynamic() {
-        let re = ResourceDef::prefix("/{name}");
-        println!("{:#?}", &re);
-
         let re = ResourceDef::prefix("/{name}/");
-        println!("{:#?}", &re);
 
         assert!(re.is_match("/name/"));
         assert!(re.is_match("/name/gs"));


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

Unnamed tails with iterator now interpolate correctly:
```rust
let re = ResourceDef::new("/foo/*");
let mut s = String::new();
assert!(re.resource_path(&mut s, &mut ["bar"].iter()));
println!("{}", s);

// Before:  /foo
// After:   /foo/bar
```

It is now possible also to build paths in the presence of unnamed tail segments using `resource_path_from_map_with_tail`.

SImplify parse_param return type by matching on new Tail element variant.