### PR TITLE
add support for io-uring

### DIFF
--- a/actix-router/src/path.rs
+++ b/actix-router/src/path.rs
@@ -122,7 +122,7 @@ impl<T: ResourcePath> Path<T> {
     /// Get matched parameter by name without type conversion
     pub fn get(&self, key: &str) -> Option<&str> {
         profile_method!(get);
-        
+
         for item in self.segments.iter() {
             if key == item.0 {
                 return match item.1 {
@@ -150,7 +150,7 @@ impl<T: ResourcePath> Path<T> {
     /// If keyed parameter is not available empty string is used as default value.
     pub fn query(&self, key: &str) -> &str {
         profile_method!(query);
-        
+
         if let Some(s) = self.get(key) {
             s
         } else {

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -21,12 +21,14 @@ path = "src/lib.rs"
 [features]
 default = ["macros"]
 macros = ["actix-macros"]
+io-uring = ["tokio-uring"]
 
 [dependencies]
 actix-macros = { version = "0.2.0", optional = true }
 
 futures-core = { version = "0.3", default-features = false }
 tokio = { version = "1.3", features = ["rt", "net", "parking_lot", "signal", "sync", "time"] }
+tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring.git", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.2", features = ["full"] }

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -39,6 +39,9 @@
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
 
+#[cfg(all(not(target_os = "linux"), feature = "io-uring"))]
+compile_error!("io_uring is a linux only feature.");
+
 use std::future::Future;
 
 use tokio::task::JoinHandle;

--- a/actix-rt/src/runtime.rs
+++ b/actix-rt/src/runtime.rs
@@ -31,11 +31,6 @@ impl Runtime {
         })
     }
 
-    /// Reference to local task set.
-    pub(crate) fn local_set(&self) -> &LocalSet {
-        &self.local
-    }
-
     /// Offload a future onto the single-threaded runtime.
     ///
     /// The returned join handle can be used to await the future's result.

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -54,7 +54,8 @@ impl System {
         let (sys_tx, sys_rx) = mpsc::unbounded_channel();
 
         let rt = Runtime::from(runtime_factory());
-        let sys_arbiter = Arbiter::in_new_system(rt.local_set());
+
+        let sys_arbiter = rt.block_on(async { Arbiter::in_new_system() });
         let system = System::construct(sys_tx, sys_arbiter.clone());
 
         system

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
+io-uring = ["actix-rt/io-uring"]
 
 [dependencies]
 actix-rt = { version = "2.0.0", default-features = false }

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -280,14 +280,24 @@ impl ServerWorker {
         let counter_clone = counter.clone();
         // every worker runs in it's own arbiter.
         // use a custom tokio runtime builder to change the settings of runtime.
-        Arbiter::with_tokio_rt(move || {
+        #[cfg(feature = "io-uring")]
+        let arbiter = {
+            // TODO: pass max blocking thread config when tokio-uring enable configuration
+            // on building runtime.
+            let _ = config.max_blocking_threads;
+            Arbiter::new()
+        };
+
+        #[cfg(not(feature = "io-uring"))]
+        let arbiter = Arbiter::with_tokio_rt(move || {
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .max_blocking_threads(config.max_blocking_threads)
                 .build()
                 .unwrap()
-        })
-        .spawn(async move {
+        });
+
+        arbiter.spawn(async move {
             let fut = factories
                 .iter()
                 .enumerate()


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Initial io-uring support with `tokio-uring` crate dependency.
Only `actix_rt::Arbiter` is started with `tokio-uring` runtime. `actix_rt::System` is left out for now.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
