### PR TITLE
improve malformed path error message

### DIFF
--- a/actix-router/src/resource.rs
+++ b/actix-router/src/resource.rs
@@ -932,7 +932,9 @@ impl ResourceDef {
                 }
                 _ => false,
             })
-            .expect("malformed dynamic segment");
+            .unwrap_or_else(|| {
+                panic!(r#"path "{}" contains malformed dynamic segment"#, pattern)
+            });
 
         let (mut param, mut unprocessed) = pattern.split_at(close_idx + 1);
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fixes [actix-web/2239](https://github.com/actix/actix-web/issues/2239)

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
Currently, a malformed path such as 
```rust
#[get("/foo/{bar")] // Missing `}`
async fn handle_foo(...) {
  ...
}
```
would panic with a generic error message:
```bash
thread 'actix-rt|system:0|arbiter:171' panicked at 'malformed dynamic segment'
```
This PR would produce a more helpful error message
```bash
thread 'actix-rt|system:0|arbiter:171' panicked at 'path "/foo/{bar" malformed dynamic segment'
```

<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
