### PR TITLE
Fix Service<u8> request documentation

### DIFF
--- a/actix-service/src/lib.rs
+++ b/actix-service/src/lib.rs
@@ -77,7 +77,7 @@ use self::ready::{err, ok, ready, Ready};
 ///
 ///      fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> { ... }
 ///
-///      fn call(&self, req: Self::Request) -> Self::Future { ... }
+///      fn call(&self, req: u8) -> Self::Future { ... }
 /// }
 /// ```
 ///


### PR DESCRIPTION
## PR Type
Documentation change

## Overview
Service documentation in actix-service/src/lib.rs still referred to Self::Request
