### PR TITLE
server: Don't listen for SIGHUP

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -3,8 +3,13 @@
 ## Unreleased - 2021-xx-xx
 * Remove `config` module. `ServiceConfig`, `ServiceRuntime` public types are removed due to this change. [#349]
 * Remove `ServerBuilder::configure` [#349]
+* Server no long listens to SIGHUP signal.
+  It actually did not take any action when receiving SIGHUP, the only thing SIGHUP did was to stop
+  the Server from receiving any future signal, because the `Signals` future stops on the first
+  signal received [#389]
 
 [#349]: https://github.com/actix/actix-net/pull/349
+[#389]: https://github.com/actix/actix-net/pull/389
 
 
 ## 2.0.0-beta.5 - 2021-04-20

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -335,7 +335,6 @@ impl ServerBuilder {
                             completion: None,
                         })
                     }
-                    _ => (),
                 }
             }
             ServerCommand::Notify(tx) => {

--- a/actix-server/src/signals.rs
+++ b/actix-server/src/signals.rs
@@ -8,8 +8,6 @@ use crate::server::Server;
 #[allow(dead_code)]
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub(crate) enum Signal {
-    /// SIGHUP
-    Hup,
     /// SIGINT
     Int,
     /// SIGTERM
@@ -41,7 +39,6 @@ impl Signals {
 
             let sig_map = [
                 (unix::SignalKind::interrupt(), Signal::Int),
-                (unix::SignalKind::hangup(), Signal::Hup),
                 (unix::SignalKind::terminate(), Signal::Term),
                 (unix::SignalKind::quit(), Signal::Quit),
             ];


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix / Other


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
The Server didn't take any action when receiving `SIGHUP`. However, `Signals` would return `Poll::Ready`, which would cause the Server to miss any other signal after that. This is probably better than just quitting on `SIGHUP`, because it's common to repurpose it for something other than quitting.

This is technically a breaking change, but it will only break the code from someone that was relying on using `SIGHUP` to stop the server from handling other future signals, which seems weird...


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
