### PR TITLE
system: run and return exit code on stop

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -1,8 +1,7 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
-
-* Add `System::run_until_stop` to allow retrieving the exit code on stop. [#411]
+* Add `System::run_with_code` to allow retrieving the exit code on stop. [#411]
 
 [#411]: https://github.com/actix/actix-net/pull/411
 

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased - 2021-xx-xx
 
+* Add `System::run_until_stop` to allow retrieving the exit code on stop. [#411]
+
+[#411]: https://github.com/actix/actix-net/pull/411
 
 ## 2.4.0 - 2021-11-05
 * Add `Arbiter::try_current` for situations where thread may or may not have Arbiter context. [#408]

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -175,8 +175,8 @@ impl System {
     }
 }
 
-#[cfg(not(feature = "io-uring"))]
 /// Runner that keeps a [System]'s event loop alive until stop message is received.
+#[cfg(not(feature = "io-uring"))]
 #[must_use = "A SystemRunner does nothing unless `run` is called."]
 #[derive(Debug)]
 pub struct SystemRunner {
@@ -190,9 +190,9 @@ pub struct SystemRunner {
 impl SystemRunner {
     /// Starts event loop and will return once [System] is [stopped](System::stop).
     pub fn run(self) -> io::Result<()> {
-        // run loop
-        let code = self.run_until_stop()?;
-        match code {
+        let exit_code = self.run_with_code()?;
+
+        match exit_code {
             0 => Ok(()),
             nonzero => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -202,12 +202,12 @@ impl SystemRunner {
     }
 
     /// Runs the event loop until [stopped](System::stop_with_code), returning the exit code.
-    pub fn run_until_stop(self) -> io::Result<i32> {
+    pub fn run_with_code(self) -> io::Result<i32> {
         let SystemRunner { rt, stop_rx, .. } = self;
 
         // run loop
         rt.block_on(stop_rx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
     }
 
     /// Runs the provided future, blocking the current thread until the future completes.
@@ -217,8 +217,8 @@ impl SystemRunner {
     }
 }
 
-#[cfg(feature = "io-uring")]
 /// Runner that keeps a [System]'s event loop alive until stop message is received.
+#[cfg(feature = "io-uring")]
 #[must_use = "A SystemRunner does nothing unless `run` is called."]
 #[derive(Debug)]
 pub struct SystemRunner;
@@ -227,7 +227,14 @@ pub struct SystemRunner;
 impl SystemRunner {
     /// Starts event loop and will return once [System] is [stopped](System::stop).
     pub fn run(self) -> io::Result<()> {
-        unimplemented!("SystemRunner::run is not implemented yet")
+        unimplemented!("SystemRunner::run is not implemented for io-uring feature yet");
+    }
+
+    /// Runs the event loop until [stopped](System::stop_with_code), returning the exit code.
+    pub fn run_with_code(self) -> io::Result<i32> {
+        unimplemented!(
+            "SystemRunner::run_with_code is not implemented for io-uring feature yet"
+        );
     }
 
     /// Runs the provided future, blocking the current thread until the future completes.

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -24,6 +24,7 @@ fn await_for_timer() {
     );
 }
 
+#[cfg(not(feature = "io-uring"))]
 #[test]
 fn run_with_code() {
     let sys = System::new();
@@ -107,8 +108,8 @@ fn wait_for_spawns() {
 
     let handle = rt.spawn(async {
         println!("running on the runtime");
-        // assertion panic is caught at task boundary
-        assert_eq!(1, 2);
+        // panic is caught at task boundary
+        panic!("intentional test panic");
     });
 
     assert!(rt.block_on(handle).is_err());

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -25,6 +25,14 @@ fn await_for_timer() {
 }
 
 #[test]
+fn run_with_code() {
+    let sys = System::new();
+    System::current().stop_with_code(42);
+    let exit_code = sys.run_with_code().expect("system stop should not error");
+    assert_eq!(exit_code, 42);
+}
+
+#[test]
 fn join_another_arbiter() {
     let time = Duration::from_secs(1);
     let instant = Instant::now();


### PR DESCRIPTION
## Overview

This adds an additional running method to `System`, which allows
consumers to retrieve the stopping code.
Additionally, the existing `run()` is reworked to use that
internally, ensuring both codepaths are tested and aligned in
behavior.

## PR Type

 - [x] New feature
 - [x] Refactor


## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
  - Test coverage inherited from existing ones, via the `run()` rework.   
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt




