### PR TITLE
fix accept timeout and worker graceful shutdown

### DIFF
--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -127,7 +127,7 @@ impl Accept {
         let mut events = mio::Events::with_capacity(256);
 
         loop {
-            if let Err(e) = self.poll.poll(&mut events, None) {
+            if let Err(e) = self.poll.poll(&mut events, self.timeout) {
                 match e.kind() {
                     io::ErrorKind::Interrupted => {}
                     _ => panic!("Poll error: {}", e),


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Accept should use it's timeout as `Mio::poll`'s deadline.

Worker now drain pending connection and drop them on server shutdown. There could be some unfortunate connection that are not handled in time but there is little benefit to force a straight sync between accept and workers.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
