### PR TITLE
actix-tls: allow getting uri from Connect

### DIFF
--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Add `Connect::request` for getting a reference to the connection request. [#415]
+
+[#415]: https://github.com/actix/actix-net/pull/415
 
 
 ## 3.0.0-beta.7 - 2021-10-20

--- a/actix-tls/src/connect/connect.rs
+++ b/actix-tls/src/connect/connect.rs
@@ -63,16 +63,16 @@ impl From<Option<SocketAddr>> for ConnectAddrs {
 
 /// Connection info.
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct Connect<T> {
-    pub(crate) req: T,
+pub struct Connect<R> {
+    pub(crate) req: R,
     pub(crate) port: u16,
     pub(crate) addr: ConnectAddrs,
     pub(crate) local_addr: Option<IpAddr>,
 }
 
-impl<T: Address> Connect<T> {
+impl<R: Address> Connect<R> {
     /// Create `Connect` instance by splitting the string by ':' and convert the second part to u16
-    pub fn new(req: T) -> Connect<T> {
+    pub fn new(req: R) -> Connect<R> {
         let (_, port) = parse_host(req.hostname());
 
         Connect {
@@ -85,7 +85,7 @@ impl<T: Address> Connect<T> {
 
     /// Create new `Connect` instance from host and address. Connector skips name resolution stage
     /// for such connect messages.
-    pub fn with_addr(req: T, addr: SocketAddr) -> Connect<T> {
+    pub fn with_addr(req: R, addr: SocketAddr) -> Connect<R> {
         Connect {
             req,
             port: 0,
@@ -156,19 +156,19 @@ impl<T: Address> Connect<T> {
         }
     }
 
-    /// Get request.
-    pub fn request(&self) -> &T {
+    /// Returns a reference to the connection request.
+    pub fn request(&self) -> &R {
         &self.req
     }
 }
 
-impl<T: Address> From<T> for Connect<T> {
-    fn from(addr: T) -> Self {
+impl<R: Address> From<R> for Connect<R> {
+    fn from(addr: R) -> Self {
         Connect::new(addr)
     }
 }
 
-impl<T: Address> fmt::Display for Connect<T> {
+impl<R: Address> fmt::Display for Connect<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.hostname(), self.port())
     }
@@ -351,5 +351,11 @@ mod tests {
             conn.local_addr.unwrap(),
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
         )
+    }
+
+    #[test]
+    fn request_ref() {
+        let conn = Connect::new("hello");
+        assert_eq!(conn.request(), &"hello")
     }
 }

--- a/actix-tls/src/connect/connect.rs
+++ b/actix-tls/src/connect/connect.rs
@@ -155,6 +155,11 @@ impl<T: Address> Connect<T> {
             ConnectAddrs::Multi(addrs) => ConnectAddrsIter::MultiOwned(addrs.into_iter()),
         }
     }
+
+    /// Get request.
+    pub fn request(&self) -> &T {
+        &self.req
+    }
 }
 
 impl<T: Address> From<T> for Connect<T> {


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
It's currently impossible to provide an alternative connector for awc.

Connector [signature](https://docs.rs/awc/3.0.0-beta.9/awc/struct.Connector.html#method.connector) is:

`S1: Service<Connect<Uri>, Response = Connection<Uri, Io1>, Error = ConnectError> + Clone,`

so Service::call looks like this:

`fn call(&self, req: Connect<Uri>) -> Self::Future`

but it's not possible to extract Uri from Connect<Uri> to construct Connection<Uri, _>. 

I found this problem while building awc uds connector: https://github.com/polachok/awc-uds