### PR TITLE
add `TlsError::into_service_error`

### DIFF
--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -4,8 +4,10 @@
 * Add configurable timeout for accepting TLS connection. [#393]
 * Added `TlsError::Timeout` variant. [#393]
 * All TLS acceptor services now use `TlsError` for their error types. [#393]
+* Added `TlsError::into_service_error`. [#420]
 
 [#393]: https://github.com/actix/actix-net/pull/393
+[#420]: https://github.com/actix/actix-net/pull/420
 
 
 ## 3.0.0-beta.8 - 2021-11-15

--- a/actix-tls/src/accept/native_tls.rs
+++ b/actix-tls/src/accept/native_tls.rs
@@ -134,7 +134,6 @@ impl<T: ActixStream + 'static> ServiceFactory<T> for Acceptor {
     type Response = TlsStream<T>;
     type Error = TlsError<Error, Infallible>;
     type Config = ();
-
     type Service = NativeTlsAcceptorService;
     type InitError = ();
     type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;

--- a/actix-tls/src/accept/rustls.rs
+++ b/actix-tls/src/accept/rustls.rs
@@ -138,7 +138,6 @@ impl<T: ActixStream> ServiceFactory<T> for Acceptor {
     type Response = TlsStream<T>;
     type Error = TlsError<io::Error, Infallible>;
     type Config = ();
-
     type Service = AcceptorService;
     type InitError = ();
     type Future = LocalBoxFuture<'static, Result<Self::Service, Self::InitError>>;

--- a/actix-tls/src/connect/tls/rustls.rs
+++ b/actix-tls/src/connect/tls/rustls.rs
@@ -115,7 +115,7 @@ where
 }
 
 pub enum RustlsConnectorServiceFuture<T, U> {
-    /// See issue https://github.com/briansmith/webpki/issues/54
+    /// See issue <https://github.com/briansmith/webpki/issues/54>
     InvalidDns,
     Future {
         connect: Connect<U>,


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Helps with the common case of getting the acceptor first and wanting to populate the service error slot later.