### PR TITLE
re-export openssl connector builder

### DIFF
--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+* Re-export `openssl::SslConnectorBuilder` in `connect::openssl::reexports`. [#???]
 
+[#???]: https://github.com/actix/actix-net/pull/???
 
 ## 3.0.0-rc.1 - 2021-11-29
 ### Added

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+
+
+## 3.0.0-rc.2 - 2021-12-10
 * Re-export `openssl::SslConnectorBuilder` in `connect::openssl::reexports`. [#???]
 
 [#???]: https://github.com/actix/actix-net/pull/???

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-tls"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 authors = [
     "Nikolay Kim <fafhrd91@gmail.com>",
     "Rob Ede <robjtede@icloud.com>",

--- a/actix-tls/src/connect/openssl.rs
+++ b/actix-tls/src/connect/openssl.rs
@@ -22,7 +22,9 @@ use crate::connect::{Connection, Host};
 pub mod reexports {
     //! Re-exports from `openssl` and `tokio-openssl` that are useful for connectors.
 
-    pub use openssl::ssl::{Error, HandshakeError, SslConnector, SslMethod};
+    pub use openssl::ssl::{
+        Error, HandshakeError, SslConnector, SslConnectorBuilder, SslMethod,
+    };
 
     pub use tokio_openssl::SslStream as AsyncSslStream;
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Chore


## PR Checklist
Check your PR fulfills the following:

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Re-export `openssl::SslConnectorBuilder` because it's useful in connector wrappers.