### PR TITLE
Made `new` constructor for the Connection type public

### DIFF
--- a/actix-tls/src/connect/connection.rs
+++ b/actix-tls/src/connect/connection.rs
@@ -14,7 +14,7 @@ pub struct Connection<R, IO> {
 
 impl<R, IO> Connection<R, IO> {
     /// Construct new `Connection` from request and IO parts.
-    pub(crate) fn new(req: R, io: IO) -> Self {
+    pub fn new(req: R, io: IO) -> Self {
         Self { req, io }
     }
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Fix

## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
There's a crate called [awc-uds](https://github.com/polachok/awc-uds/pull/2/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R49) which is used to add support for Unix Domain Sockets for awc. And it needs to construct `connect::connection::Connection` type when implementing `actix_service::Service`, after this [PR](https://github.com/actix/actix-net/commit/5dc2bfcb01b899d2d1e5d92e172fa3ab75bdaf74), it's not possible to construct `Connection` anymore, as all the fields and constructor are made crate private. 