### PR TITLE
do not remove the uds socket on pause

### DIFF
--- a/actix-server/examples/tcp-echo.rs
+++ b/actix-server/examples/tcp-echo.rs
@@ -31,7 +31,7 @@ async fn run() -> io::Result<()> {
     let count = Arc::new(AtomicUsize::new(0));
 
     let addr = ("127.0.0.1", 8080);
-    info!("starting server on port: {}", &addr.0);
+    info!("starting server on: {}:{}", &addr.0, &addr.1);
 
     // Bind socket address and start worker(s). By default, the server uses the number of physical
     // CPU cores as the worker count. For this reason, the closure passed to bind needs to return

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -217,8 +217,6 @@ impl Accept {
                         self.deregister_all(sockets);
                     }
 
-                    self.terminate_all(sockets);
-
                     return true;
                 }
 
@@ -330,10 +328,6 @@ impl Accept {
             // Socket info with a timeout is already deregistered so skip them.
             .filter(|(timeout, _)| timeout.is_none())
             .for_each(|(_, info)| self.deregister_logged(info));
-    }
-
-    fn terminate_all(&self, sockets: &mut [ServerSocketInfo]) {
-        sockets.iter().for_each(|s| s.lst.terminate());
     }
 
     // Send connection to worker and handle error.

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -217,6 +217,8 @@ impl Accept {
                         self.deregister_all(sockets);
                     }
 
+                    self.terminate_all(sockets);
+
                     return true;
                 }
 
@@ -328,6 +330,10 @@ impl Accept {
             // Socket info with a timeout is already deregistered so skip them.
             .filter(|(timeout, _)| timeout.is_none())
             .for_each(|(_, info)| self.deregister_logged(info));
+    }
+
+    fn terminate_all(&self, sockets: &mut[ServerSocketInfo]) {
+        sockets.iter().for_each(|s| s.lst.terminate());
     }
 
     // Send connection to worker and handle error.

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -332,7 +332,7 @@ impl Accept {
             .for_each(|(_, info)| self.deregister_logged(info));
     }
 
-    fn terminate_all(&self, sockets: &mut[ServerSocketInfo]) {
+    fn terminate_all(&self, sockets: &mut [ServerSocketInfo]) {
         sockets.iter().for_each(|s| s.lst.terminate());
     }
 

--- a/actix-server/src/socket.rs
+++ b/actix-server/src/socket.rs
@@ -38,9 +38,7 @@ impl MioListener {
         match *self {
             MioListener::Tcp(ref lst) => lst.accept().map(|(stream, _)| MioStream::Tcp(stream)),
             #[cfg(unix)]
-            MioListener::Uds(ref lst) => {
-                lst.accept().map(|(stream, _)| MioStream::Uds(stream))
-            }
+            MioListener::Uds(ref lst) => lst.accept().map(|(stream, _)| MioStream::Uds(stream)),
         }
     }
 
@@ -49,16 +47,15 @@ impl MioListener {
             MioListener::Tcp(_) => (),
             #[cfg(unix)]
             MioListener::Uds(ref lst) => {
-                    if let Ok(addr) = lst.local_addr() {
-                        if let Some(path) = addr.as_pathname() {
-                            let _ = std::fs::remove_file(path);
-                        }
+                if let Ok(addr) = lst.local_addr() {
+                    if let Some(path) = addr.as_pathname() {
+                        let _ = std::fs::remove_file(path);
                     }
                 }
+            }
         }
     }
 }
-
 
 impl Source for MioListener {
     fn register(
@@ -91,7 +88,7 @@ impl Source for MioListener {
         match *self {
             MioListener::Tcp(ref mut lst) => lst.deregister(registry),
             #[cfg(unix)]
-            MioListener::Uds(ref mut lst) => lst.deregister(registry)
+            MioListener::Uds(ref mut lst) => lst.deregister(registry),
         }
     }
 }


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Add a terminate function to the listener socket so the socket file is not remove in the deregister, but really when it is necessary. For a tcp socket, we have nothing to do and in the deregister, there is nothing left special to do for a UDS.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

Closes #364 #97