### PR TITLE
bump tokio-util to 0.7

### DIFF
--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+- Updated `tokio-util` dependency to `0.7.0`. [#???]
+
+[#338]: https://github.com/actix/actix-net/pull/338
 
 
 ## 0.4.2 - 2021-12-31

--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2021-xx-xx
+
+
+## 0.5.0 - 2022-02-15
 - Updated `tokio-util` dependency to `0.7.0`. [#???]
 
 [#338]: https://github.com/actix/actix-net/pull/338

--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -4,9 +4,9 @@
 
 
 ## 0.5.0 - 2022-02-15
-- Updated `tokio-util` dependency to `0.7.0`. [#???]
+- Updated `tokio-util` dependency to `0.7.0`. [#446]
 
-[#338]: https://github.com/actix/actix-net/pull/338
+[#446]: https://github.com/actix/actix-net/pull/446
 
 
 ## 0.4.2 - 2021-12-31

--- a/actix-codec/Cargo.toml
+++ b/actix-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-codec"
-version = "0.4.2"
+version = "0.5.0"
 authors = [
     "Nikolay Kim <fafhrd91@gmail.com>",
     "Rob Ede <robjtede@icloud.com>",

--- a/actix-codec/Cargo.toml
+++ b/actix-codec/Cargo.toml
@@ -17,7 +17,7 @@ name = "actix_codec"
 path = "src/lib.rs"
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "1.2"
 bytes = "1"
 futures-core = { version = "0.3.7", default-features = false }
 futures-sink = { version = "0.3.7", default-features = false }
@@ -25,7 +25,7 @@ log = "0.4"
 memchr = "2.3"
 pin-project-lite = "0.2"
 tokio = "1.13.1"
-tokio-util = { version = "0.6", features = ["codec", "io"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/actix-codec/src/lines.rs
+++ b/actix-codec/src/lines.rs
@@ -7,8 +7,8 @@ use super::{Decoder, Encoder};
 
 /// Lines codec. Reads/writes line delimited strings.
 ///
-/// Will split input up by LF or CRLF delimiters. I.e. carriage return characters at the end of
-/// lines are not preserved.
+/// Will split input up by LF or CRLF delimiters. Carriage return characters at the end of lines are
+/// not preserved.
 #[derive(Debug, Copy, Clone, Default)]
 #[non_exhaustive]
 pub struct LinesCodec;

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.13.1", features = ["sync"] }
 tokio-uring = { version = "0.2", optional = true }
 
 [dev-dependencies]
-actix-codec = "0.4.2"
+actix-codec = "0.5.0"
 actix-rt = "2.6.0"
 
 bytes = "1"

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -3,6 +3,10 @@
 ## Unreleased - 2021-xx-xx
 
 
+## 3.0.3 - 2022-02-15
+- No significant changes since `3.0.2`.
+
+
 ## 3.0.2 - 2022-01-28
 - Expose `connect::Connection::new`. [#439]
 

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -50,7 +50,7 @@ actix-utils = "3.0.0"
 futures-core = { version = "0.3.7", default-features = false, features = ["alloc"] }
 log = "0.4"
 pin-project-lite = "0.2.7"
-tokio-util = { version = "0.6.3", default-features = false }
+tokio-util = "0.7"
 
 # uri
 http = { version = "0.2.3", optional = true }

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -42,7 +42,7 @@ native-tls = ["tokio-native-tls"]
 uri = ["http"]
 
 [dependencies]
-actix-codec = "0.4.2"
+actix-codec = "0.5.0"
 actix-rt = { version = "2.2.0", default-features = false }
 actix-service = "2.0.0"
 actix-utils = "3.0.0"

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-tls"
-version = "3.0.2"
+version = "3.0.3"
 authors = [
     "Nikolay Kim <fafhrd91@gmail.com>",
     "Rob Ede <robjtede@icloud.com>",

--- a/actix-tls/src/connect/tcp.rs
+++ b/actix-tls/src/connect/tcp.rs
@@ -79,7 +79,7 @@ pub enum TcpConnectorFut<R> {
         port: u16,
         local_addr: Option<IpAddr>,
         addrs: Option<VecDeque<SocketAddr>>,
-        stream: ReusableBoxFuture<Result<TcpStream, io::Error>>,
+        stream: ReusableBoxFuture<'static, Result<TcpStream, io::Error>>,
     },
 
     Error(Option<ConnectError>),


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Dep Bump (breaking) + Release


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
tokio-util was released a few days ago and it would be breaking on actix-http to update it midway through v4 cycle