### PR TITLE
add track_caller atrtibute to spawn calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,14 @@ jobs:
           command: install
           args: cargo-hack
 
+      - name: Generate Cargo.lock
+        uses: actions-rs/cargo@v1
+        with: { command: generate-lockfile }
+
+      - name: Tweak lockfile
+        run: |
+          cargo update -p=native-tls --precise=0.2.8
+
       - name: check lib
         if: >
           matrix.target.os != 'ubuntu-latest'
@@ -142,10 +150,9 @@ jobs:
         with: { command: generate-lockfile }
 
       - name: Tweak lockfile
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-          args: -p=rustls --precise=0.20.2
+        run: |
+          cargo update -p=rustls --precise=0.20.2
+          cargo update -p=native-tls --precise=0.2.8
 
       - name: tests
         run: |

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
+- Add `#[track_caller]` attribute to `spawn` functions and methods. [#454]
+
+[#454]: https://github.com/actix/actix-net/pull/454
 
 
 ## 2.7.0 - 2022-03-08

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -260,6 +260,7 @@ impl Arbiter {
     /// If you require a result, include a response channel in the future.
     ///
     /// Returns true if future was sent successfully and false if the Arbiter has died.
+    #[track_caller]
     pub fn spawn<Fut>(&self, future: Fut) -> bool
     where
         Fut: Future<Output = ()> + Send + 'static,
@@ -275,6 +276,7 @@ impl Arbiter {
     /// channel in the function.
     ///
     /// Returns true if function was sent successfully and false if the Arbiter has died.
+    #[track_caller]
     pub fn spawn_fn<F>(&self, f: F) -> bool
     where
         F: FnOnce() + Send + 'static,

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -195,6 +195,7 @@ pub mod task {
 /// assert!(handle.await.unwrap_err().is_cancelled());
 /// # });
 /// ```
+#[track_caller]
 #[inline]
 pub fn spawn<Fut>(f: Fut) -> JoinHandle<Fut::Output>
 where

--- a/actix-rt/src/runtime.rs
+++ b/actix-rt/src/runtime.rs
@@ -53,6 +53,7 @@ impl Runtime {
     /// # Panics
     /// This function panics if the spawn fails. Failure occurs if the executor is currently at
     /// capacity and is unable to spawn a new future.
+    #[track_caller]
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
@@ -73,6 +74,7 @@ impl Runtime {
     ///
     /// The caller is responsible for ensuring that other spawned futures complete execution by
     /// calling `block_on` or `run`.
+    #[track_caller]
     pub fn block_on<F>(&self, f: F) -> F::Output
     where
         F: Future,

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -204,6 +204,7 @@ impl SystemRunner {
     }
 
     /// Runs the provided future, blocking the current thread until the future completes.
+    #[track_caller]
     #[inline]
     pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
         self.rt.block_on(fut)


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Partially addresses actix/actix-web#2646 by adding `#[track_caller]` to spawn and block_on fns/methods.

closes #445