### PR TITLE
feat: impls for Box and String conversions

### DIFF
--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.49.
-- Implement `From<Box<str>>` and `Into<String>`
+- Implement `From<Box<str>>` and `Into<String>`. [#458]
+
+[#458]: https://github.com/actix/actix-net/pull/458
 
 
 ## 1.0.0 - 2020-12-31

--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.49.
+- Implement `From<Box<str>>` and `Into<String>`
 
 
 ## 1.0.0 - 2020-12-31

--- a/bytestring/src/lib.rs
+++ b/bytestring/src/lib.rs
@@ -6,7 +6,11 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{borrow, convert::TryFrom, fmt, hash, ops, str};
 
 use bytes::Bytes;
@@ -107,6 +111,20 @@ impl From<&str> for ByteString {
     #[inline]
     fn from(value: &str) -> Self {
         Self(Bytes::copy_from_slice(value.as_ref()))
+    }
+}
+
+impl From<Box<str>> for ByteString {
+    #[inline]
+    fn from(value: Box<str>) -> Self {
+        Self(Bytes::from(value.into_boxed_bytes()))
+    }
+}
+
+impl From<ByteString> for String {
+    #[inline]
+    fn from(value: ByteString) -> Self {
+        value.to_string()
     }
 }
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Add impls for `From<Box<str>>`, which can be cheaply done via the `From<Box<[u8]>>` defined in `Bytes`, and `From<ByteString> for String`. These are in service of some goals I have in neoeinstein/aliri_braid#13, specifically allowing me to construct `Bytes`-backed strongly-typed string wrappers. Specifically, in this section of code:

```rust
use aliri_braid::braid;
use bytestring::ByteString;

#[braid(serde)]
pub struct BytesCustomType(ByteString);
```

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
