### PR TITLE
Set depth of `--feature-powerset` on Windows CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,6 +18,11 @@ ci-test = "       hack --feature-powerset --exclude=actix-rt --exclude=actix-ser
 ci-test-rt = "    hack --feature-powerset --exclude-features=io-uring test --package=actix-rt     --lib --tests --no-fail-fast -- --nocapture"
 ci-test-server = "hack --feature-powerset --exclude-features=io-uring test --package=actix-server --lib --tests --no-fail-fast -- --nocapture"
 
+# tests avoiding io-uring feature on Windows
+ci-test-win = "       hack --feature-powerset --depth 2 --exclude=actix-rt --exclude=actix-server --exclude-features=io-uring test --workspace --lib --tests --no-fail-fast -- --nocapture"
+ci-test-rt-win = "    hack --feature-powerset --depth 2 --exclude-features=io-uring test --package=actix-rt     --lib --tests --no-fail-fast -- --nocapture"
+ci-test-server-win = "hack --feature-powerset --depth 2 --exclude-features=io-uring test --package=actix-server --lib --tests --no-fail-fast -- --nocapture"
+
 # test with io-uring feature
 ci-test-rt-linux = "    hack --feature-powerset test --package=actix-rt     --lib --tests --no-fail-fast -- --nocapture"
 ci-test-server-linux = "hack --feature-powerset test --package=actix-server --lib --tests --no-fail-fast -- --nocapture"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,19 @@ jobs:
         with: { command: ci-check-linux }
 
       - name: tests
-        if: >
-          matrix.target.os != 'ubuntu-latest'
-          && matrix.target.triple != 'x86_64-pc-windows-gnu'
+        if: matrix.target.os == 'macos-latest'
         run: |
           cargo ci-test
           cargo ci-test-rt
           cargo ci-test-server
+      - name: tests
+        if: >
+          matrix.target.os == 'windows-latest'
+          && matrix.target.triple != 'x86_64-pc-windows-gnu'
+        run: |
+          cargo ci-test-win
+          cargo ci-test-rt-win
+          cargo ci-test-server-win
       - name: tests
         if: matrix.target.os == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
Windows CI often uses up CI resources on feature-powerset tests.
To avoid that, this sets depth to 50 on Windows.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Chore


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
