### PR TITLE
normalize logs capital letter

### DIFF
--- a/actix-server/examples/file-reader.rs
+++ b/actix-server/examples/file-reader.rs
@@ -74,7 +74,7 @@ async fn run() -> io::Result<()> {
                 // close connection after file has been copied to TCP stream
                 Ok(())
             })
-            .map_err(|err| tracing::error!("Service Error: {:?}", err))
+            .map_err(|err| tracing::error!("service Error: {:?}", err))
         })?
         .workers(2)
         .run()

--- a/actix-server/examples/file-reader.rs
+++ b/actix-server/examples/file-reader.rs
@@ -74,7 +74,7 @@ async fn run() -> io::Result<()> {
                 // close connection after file has been copied to TCP stream
                 Ok(())
             })
-            .map_err(|err| tracing::error!("service Error: {:?}", err))
+            .map_err(|err| tracing::error!("service error: {:?}", err))
         })?
         .workers(2)
         .run()

--- a/actix-server/examples/tcp-echo.rs
+++ b/actix-server/examples/tcp-echo.rs
@@ -64,7 +64,7 @@ async fn run() -> io::Result<()> {
 
                             // stream error; bail from loop with error
                             Err(err) => {
-                                tracing::error!("stream Error: {:?}", err);
+                                tracing::error!("stream error: {:?}", err);
                                 return Err(());
                             }
                         }
@@ -74,7 +74,7 @@ async fn run() -> io::Result<()> {
                     Ok((buf.freeze(), size))
                 }
             })
-            .map_err(|err| tracing::error!("service Error: {:?}", err))
+            .map_err(|err| tracing::error!("service error: {:?}", err))
             .and_then(move |(_, size)| {
                 let num = num2.load(Ordering::SeqCst);
                 tracing::info!("[{}] total bytes read: {}", num, size);

--- a/actix-server/examples/tcp-echo.rs
+++ b/actix-server/examples/tcp-echo.rs
@@ -64,7 +64,7 @@ async fn run() -> io::Result<()> {
 
                             // stream error; bail from loop with error
                             Err(err) => {
-                                tracing::error!("Stream Error: {:?}", err);
+                                tracing::error!("stream Error: {:?}", err);
                                 return Err(());
                             }
                         }
@@ -74,7 +74,7 @@ async fn run() -> io::Result<()> {
                     Ok((buf.freeze(), size))
                 }
             })
-            .map_err(|err| tracing::error!("Service Error: {:?}", err))
+            .map_err(|err| tracing::error!("service Error: {:?}", err))
             .and_then(move |(_, size)| {
                 let num = num2.load(Ordering::SeqCst);
                 tracing::info!("[{}] total bytes read: {}", num, size);

--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -140,7 +140,7 @@ impl Accept {
                     WAKER_TOKEN => {
                         let exit = self.handle_waker(sockets);
                         if exit {
-                            info!("Accept thread stopped");
+                            info!("accept thread stopped");
                             return;
                         }
                     }
@@ -297,16 +297,16 @@ impl Accept {
 
     fn register_logged(&self, info: &mut ServerSocketInfo) {
         match self.register(info) {
-            Ok(_) => debug!("Resume accepting connections on {}", info.lst.local_addr()),
-            Err(err) => error!("Can not register server socket {}", err),
+            Ok(_) => debug!("resume accepting connections on {}", info.lst.local_addr()),
+            Err(err) => error!("can not register server socket {}", err),
         }
     }
 
     fn deregister_logged(&self, info: &mut ServerSocketInfo) {
         match self.poll.registry().deregister(&mut info.lst) {
-            Ok(_) => debug!("Paused accepting connections on {}", info.lst.local_addr()),
+            Ok(_) => debug!("paused accepting connections on {}", info.lst.local_addr()),
             Err(err) => {
-                error!("Can not deregister server socket {}", err)
+                error!("can not deregister server socket {}", err)
             }
         }
     }
@@ -350,7 +350,7 @@ impl Accept {
                 self.remove_next();
 
                 if self.handles.is_empty() {
-                    error!("No workers");
+                    error!("no workers");
                     // All workers are gone and Conn is nowhere to be sent.
                     // Treat this situation as Ok and drop Conn.
                     return Ok(());
@@ -399,7 +399,7 @@ impl Accept {
                 Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => return,
                 Err(ref err) if connection_error(err) => continue,
                 Err(err) => {
-                    error!("Error accepting connection: {}", err);
+                    error!("error accepting connection: {}", err);
 
                     // deregister listener temporary
                     self.deregister_logged(info);

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -197,7 +197,7 @@ impl ServerBuilder {
         if self.sockets.is_empty() {
             panic!("Server should have at least one bound socket");
         } else {
-            info!("Starting {} workers", self.threads);
+            info!("starting {} workers", self.threads);
             Server::new(self)
         }
     }

--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -193,14 +193,14 @@ impl ServerInner {
         let is_tokio = tokio::runtime::Handle::try_current().is_ok();
 
         match (is_actix, is_tokio) {
-            (true, _) => info!("Actix runtime found; starting in Actix runtime"),
-            (_, true) => info!("Tokio runtime found; starting in existing Tokio runtime"),
-            (_, false) => panic!("Actix or Tokio runtime not found; halting"),
+            (true, _) => info!("actix runtime found; starting in actix runtime"),
+            (_, true) => info!("tokio runtime found; starting in existing tokio runtime"),
+            (_, false) => panic!("actix or tokio runtime not found; halting"),
         }
 
         for (_, name, lst) in &builder.sockets {
             info!(
-                r#"Starting service: "{}", workers: {}, listening on: {}"#,
+                r#"starting service: "{}", workers: {}, listening on: {}"#,
                 name,
                 builder.threads,
                 lst.local_addr()
@@ -283,7 +283,7 @@ impl ServerInner {
                 // TODO: maybe just return with warning log if not found ?
                 assert!(self.worker_handles.iter().any(|wrk| wrk.idx == idx));
 
-                error!("Worker {} has died; restarting", idx);
+                error!("worker {} has died; restarting", idx);
 
                 let factories = self
                     .services

--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -193,9 +193,9 @@ impl ServerInner {
         let is_tokio = tokio::runtime::Handle::try_current().is_ok();
 
         match (is_actix, is_tokio) {
-            (true, _) => info!("actix runtime found; starting in actix runtime"),
-            (_, true) => info!("tokio runtime found; starting in existing tokio runtime"),
-            (_, false) => panic!("actix or tokio runtime not found; halting"),
+            (true, _) => info!("Actix runtime found; starting in Actix runtime"),
+            (_, true) => info!("Tokio runtime found; starting in existing Tokio runtime"),
+            (_, false) => panic!("Actix or Tokio runtime not found; halting"),
         }
 
         for (_, name, lst) in &builder.sockets {

--- a/actix-server/src/service.rs
+++ b/actix-server/src/service.rs
@@ -78,7 +78,7 @@ where
                 Ok(())
             }
             Err(err) => {
-                error!("can not convert to an async tcp stream: {}", err);
+                error!("can not convert to an async TCP stream: {}", err);
                 Err(())
             }
         })

--- a/actix-server/src/service.rs
+++ b/actix-server/src/service.rs
@@ -78,7 +78,7 @@ where
                 Ok(())
             }
             Err(err) => {
-                error!("Can not convert to an async tcp stream: {}", err);
+                error!("can not convert to an async tcp stream: {}", err);
                 Err(())
             }
         })

--- a/actix-server/src/signals.rs
+++ b/actix-server/src/signals.rs
@@ -70,7 +70,7 @@ impl Signals {
                         .map(|tokio_sig| (*sig, tokio_sig))
                         .map_err(|e| {
                             tracing::error!(
-                                "Can not initialize stream handler for {:?} err: {}",
+                                "can not initialize stream handler for {:?} err: {}",
                                 sig,
                                 e
                             )

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -337,7 +337,7 @@ impl ServerWorker {
                                     Ok((token, svc)) => services.push((idx, token, svc)),
 
                                     Err(err) => {
-                                        error!("Can not start worker: {:?}", err);
+                                        error!("can not start worker: {:?}", err);
                                         return Err(io::Error::new(
                                             io::ErrorKind::Other,
                                             format!("can not start server service {}", idx),
@@ -436,7 +436,7 @@ impl ServerWorker {
                                 Ok((token, svc)) => services.push((idx, token, svc)),
 
                                 Err(err) => {
-                                    error!("Can not start worker: {:?}", err);
+                                    error!("can not start worker: {:?}", err);
                                     Arbiter::current().stop();
                                     factory_tx
                                         .send(Err(io::Error::new(
@@ -476,7 +476,7 @@ impl ServerWorker {
 
     fn restart_service(&mut self, idx: usize, factory_id: usize) {
         let factory = &self.factories[factory_id];
-        trace!("Service {:?} failed, restarting", factory.name(idx));
+        trace!("service {:?} failed, restarting", factory.name(idx));
         self.services[idx].status = WorkerServiceStatus::Restarting;
         self.state = WorkerState::Restarting(Restart {
             factory_id,
@@ -508,7 +508,7 @@ impl ServerWorker {
                     Poll::Ready(Ok(_)) => {
                         if srv.status == WorkerServiceStatus::Unavailable {
                             trace!(
-                                "Service {:?} is available",
+                                "service {:?} is available",
                                 self.factories[srv.factory_idx].name(idx)
                             );
                             srv.status = WorkerServiceStatus::Available;
@@ -519,7 +519,7 @@ impl ServerWorker {
 
                         if srv.status == WorkerServiceStatus::Available {
                             trace!(
-                                "Service {:?} is unavailable",
+                                "service {:?} is unavailable",
                                 self.factories[srv.factory_idx].name(idx)
                             );
                             srv.status = WorkerServiceStatus::Unavailable;
@@ -527,7 +527,7 @@ impl ServerWorker {
                     }
                     Poll::Ready(Err(_)) => {
                         error!(
-                            "Service {:?} readiness check returned error, restarting",
+                            "service {:?} readiness check returned error, restarting",
                             self.factories[srv.factory_idx].name(idx)
                         );
                         srv.status = WorkerServiceStatus::Failed;
@@ -590,11 +590,11 @@ impl Future for ServerWorker {
         {
             let num = this.counter.total();
             if num == 0 {
-                info!("Shutting down idle worker");
+                info!("shutting down idle worker");
                 let _ = tx.send(true);
                 return Poll::Ready(());
             } else if graceful {
-                info!("Graceful worker shutdown; finishing {} connections", num);
+                info!("graceful worker shutdown; finishing {} connections", num);
                 this.shutdown(false);
 
                 this.state = WorkerState::Shutdown(Shutdown {
@@ -603,7 +603,7 @@ impl Future for ServerWorker {
                     tx,
                 });
             } else {
-                info!("Force shutdown worker, closing {} connections", num);
+                info!("force shutdown worker, closing {} connections", num);
                 this.shutdown(true);
 
                 let _ = tx.send(false);
@@ -638,7 +638,7 @@ impl Future for ServerWorker {
                 assert_eq!(token, token_new);
 
                 trace!(
-                    "Service {:?} has been restarted",
+                    "service {:?} has been restarted",
                     this.factories[factory_id].name(token)
                 );
 
@@ -685,7 +685,7 @@ impl Future for ServerWorker {
                 match this.check_readiness(cx) {
                     Ok(true) => {}
                     Ok(false) => {
-                        trace!("Worker is unavailable");
+                        trace!("worker is unavailable");
                         this.state = WorkerState::Unavailable;
                         return self.poll(cx);
                     }

--- a/actix-server/tests/server.rs
+++ b/actix-server/tests/server.rs
@@ -186,9 +186,9 @@ fn test_start() {
 #[actix_rt::test]
 async fn test_max_concurrent_connections() {
     // Note:
-    // A tcp listener would accept connects based on it's backlog setting.
+    // A TCP listener would accept connects based on it's backlog setting.
     //
-    // The limit test on the other hand is only for concurrent tcp stream limiting a work
+    // The limit test on the other hand is only for concurrent TCP stream limiting a work
     // thread accept.
 
     use tokio::io::AsyncWriteExt;

--- a/actix-tls/src/connect/native_tls.rs
+++ b/actix-tls/src/connect/native_tls.rs
@@ -74,16 +74,16 @@ where
         let connector = self.connector.clone();
 
         Box::pin(async move {
-            trace!("SSL Handshake start for: {:?}", stream.hostname());
+            trace!("SSL handshake start for: {:?}", stream.hostname());
             connector
                 .connect(stream.hostname(), io)
                 .await
                 .map(|res| {
-                    trace!("SSL Handshake success: {:?}", stream.hostname());
+                    trace!("SSL handshake success: {:?}", stream.hostname());
                     stream.replace_io(res).1
                 })
                 .map_err(|e| {
-                    trace!("SSL Handshake error: {:?}", e);
+                    trace!("SSL handshake error: {:?}", e);
                     io::Error::new(io::ErrorKind::Other, format!("{}", e))
                 })
         })

--- a/actix-tls/src/connect/native_tls.rs
+++ b/actix-tls/src/connect/native_tls.rs
@@ -74,16 +74,16 @@ where
         let connector = self.connector.clone();
 
         Box::pin(async move {
-            trace!("SSL handshake start for: {:?}", stream.hostname());
+            trace!("TLS handshake start for: {:?}", stream.hostname());
             connector
                 .connect(stream.hostname(), io)
                 .await
                 .map(|res| {
-                    trace!("SSL handshake success: {:?}", stream.hostname());
+                    trace!("TLS handshake success: {:?}", stream.hostname());
                     stream.replace_io(res).1
                 })
                 .map_err(|e| {
-                    trace!("SSL handshake error: {:?}", e);
+                    trace!("TLS handshake error: {:?}", e);
                     io::Error::new(io::ErrorKind::Other, format!("{}", e))
                 })
         })

--- a/actix-tls/src/connect/openssl.rs
+++ b/actix-tls/src/connect/openssl.rs
@@ -97,7 +97,8 @@ where
     actix_service::always_ready!();
 
     fn call(&self, stream: Connection<R, IO>) -> Self::Future {
-        trace!("SSL handshake start for: {:?}", stream.hostname());
+        trace!("TLS handshake start for: {:?}", stream.hostname());
+
         let (io, stream) = stream.replace_io(());
         let host = stream.hostname();
 
@@ -137,11 +138,11 @@ where
         match ready!(Pin::new(this.io.as_mut().unwrap()).poll_connect(cx)) {
             Ok(_) => {
                 let stream = this.stream.take().unwrap();
-                trace!("SSL handshake success: {:?}", stream.hostname());
+                trace!("TLS handshake success: {:?}", stream.hostname());
                 Poll::Ready(Ok(stream.replace_io(this.io.take().unwrap()).1))
             }
             Err(err) => {
-                trace!("SSL handshake error: {:?}", err);
+                trace!("TLS handshake error: {:?}", err);
                 Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::Other,
                     format!("{}", err),

--- a/actix-tls/src/connect/openssl.rs
+++ b/actix-tls/src/connect/openssl.rs
@@ -97,7 +97,7 @@ where
     actix_service::always_ready!();
 
     fn call(&self, stream: Connection<R, IO>) -> Self::Future {
-        trace!("SSL Handshake start for: {:?}", stream.hostname());
+        trace!("SSL handshake start for: {:?}", stream.hostname());
         let (io, stream) = stream.replace_io(());
         let host = stream.hostname();
 
@@ -137,11 +137,11 @@ where
         match ready!(Pin::new(this.io.as_mut().unwrap()).poll_connect(cx)) {
             Ok(_) => {
                 let stream = this.stream.take().unwrap();
-                trace!("SSL Handshake success: {:?}", stream.hostname());
+                trace!("SSL handshake success: {:?}", stream.hostname());
                 Poll::Ready(Ok(stream.replace_io(this.io.take().unwrap()).1))
             }
             Err(err) => {
-                trace!("SSL Handshake error: {:?}", err);
+                trace!("SSL handshake error: {:?}", err);
                 Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::Other,
                     format!("{}", err),

--- a/actix-tls/src/connect/rustls.rs
+++ b/actix-tls/src/connect/rustls.rs
@@ -101,7 +101,7 @@ where
     actix_service::always_ready!();
 
     fn call(&self, connection: Connection<R, IO>) -> Self::Future {
-        trace!("SSL handshake start for: {:?}", connection.hostname());
+        trace!("TLS handshake start for: {:?}", connection.hostname());
         let (stream, connection) = connection.replace_io(());
 
         match ServerName::try_from(connection.hostname()) {
@@ -140,7 +140,7 @@ where
             Self::Future { connect, connection } => {
                 let stream = ready!(Pin::new(connect).poll(cx))?;
                 let connection = connection.take().unwrap();
-                trace!("SSL handshake success: {:?}", connection.hostname());
+                trace!("TLS handshake success: {:?}", connection.hostname());
                 Poll::Ready(Ok(connection.replace_io(stream).1))
             }
         }

--- a/actix-tls/src/connect/rustls.rs
+++ b/actix-tls/src/connect/rustls.rs
@@ -101,7 +101,7 @@ where
     actix_service::always_ready!();
 
     fn call(&self, connection: Connection<R, IO>) -> Self::Future {
-        trace!("SSL Handshake start for: {:?}", connection.hostname());
+        trace!("SSL handshake start for: {:?}", connection.hostname());
         let (stream, connection) = connection.replace_io(());
 
         match ServerName::try_from(connection.hostname()) {
@@ -140,7 +140,7 @@ where
             Self::Future { connect, connection } => {
                 let stream = ready!(Pin::new(connect).poll(cx))?;
                 let connection = connection.take().unwrap();
-                trace!("SSL Handshake success: {:?}", connection.hostname());
+                trace!("SSL handshake success: {:?}", connection.hostname());
                 Poll::Ready(Ok(connection.replace_io(stream).1))
             }
         }

--- a/actix-tls/src/connect/tcp.rs
+++ b/actix-tls/src/connect/tcp.rs
@@ -114,8 +114,8 @@ impl<R: Host> TcpConnectorFut<R> {
                 stream: ReusableBoxFuture::new(connect(addr, local_addr)),
             },
 
-            // when resolver returns multiple socket addr for request they would be popped from
-            // front end of queue and returns with the first successful tcp connection.
+            // When resolver returns multiple socket addr for request they would be popped from
+            // front end of queue and returns with the first successful TCP connection.
             ConnectAddrs::Multi(mut addrs) => {
                 let addr = addrs.pop_front().unwrap();
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Refactor / Code Style

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

(not sure if my pr should tick other boxes, although some words in docs/code style would probably help)

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

It seems that most packages in Rust uses lower case letters at the begging of the logs, and also Go code style recommends same style.
This crate uses a mix of upper and lower case, so I've decided to fix it to lower where appropriate. 
I've searched for `debug/trace/info/warn/error` keywords and changed the letters, if it isn't a common upper case abbreviation.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
