### PR TITLE
Add ByteString::slice_ref

### DIFF
--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased - 2022-xx-xx
 - Minimum supported Rust version (MSRV) is now 1.57.
+- Add `ByteString::slice_ref` which can safely slice a `ByteString` into a new one with zero copy. [#470]
 
+[#470]: https://github.com/actix/actix-net/pull/470
 
 ## 1.1.0 - 2022-06-11
 - Implement `From<Box<str>>` for `ByteString`. [#458]


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

Add `ByteString::slice_ref` which can slice a `ByteString` into a new one with zero copy.
