### PR TITLE
fix no_std compatibility

### DIFF
--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
+- Fix no_std compatibility. [#471]
+
+[#471]: https://github.com/actix/actix-net/pull/471
 
 
 ## 1.2.0 - 2022-11-07

--- a/bytestring/Cargo.toml
+++ b/bytestring/Cargo.toml
@@ -18,7 +18,7 @@ name = "bytestring"
 path = "src/lib.rs"
 
 [dependencies]
-bytes = "1.2"
+bytes = { version = "1.2", default-features = false }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
The bytes crate is only no-std with no default features... if you try to use bytestring for an actual no_std target, it wont work. 
Bug fix: make sure we depend on bytes with no default features.
suggestion: Add step in CI that tries to build for a no_std target, to make sure no_std compatibility is kept in the future.



