### PR TITLE
Add getter methods for actix_rt::Runtime and tokio::runtime::Runtime

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## Unreleased - 2023-xx-xx
 
-- Add `actix_rt::System::runtime()` method to retrieve the underlying `actix_rt::Runtime` runtime
-- Add `actix_rt::Runtime::tokio_runtime()` method to retrieve the underlying Tokio runtime
+- Add `actix_rt::System::runtime()` method to retrieve the underlying `actix_rt::Runtime` runtime.
+- Add `actix_rt::Runtime::tokio_runtime()` method to retrieve the underlying Tokio runtime.
 - Minimum supported Rust version (MSRV) is now 1.65.
 
 ## 2.8.0 - 2022-12-21

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased - 2023-xx-xx
 
 - Minimum supported Rust version (MSRV) is now 1.60.
+- Add `actix_rt::System::runtime()` method to retrieve the underlying `actix_rt::Runtime` runtime
+- Add `actix_rt::Runtime::tokio_runtime()` method to retrieve the underlying Tokio runtime
 
 ## 2.8.0 - 2022-12-21
 

--- a/actix-rt/src/runtime.rs
+++ b/actix-rt/src/runtime.rs
@@ -61,6 +61,65 @@ impl Runtime {
         self.local.spawn_local(future)
     }
 
+    /// Retrieves a reference to the underlying Tokio runtime associated with this instance.
+    ///
+    /// The Tokio runtime is responsible for executing asynchronous tasks and managing
+    /// the event loop for an asynchronous Rust program. This method allows accessing
+    /// the runtime to interact with its features directly.
+    ///
+    /// In a typical use case, you might need to share the same runtime between different
+    /// modules of your project. For example, a module might require a `tokio::runtime::Handle`
+    /// to spawn tasks on the same runtime, or the runtime itself to configure more complex
+    /// behaviours.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use actix_rt::Runtime;
+    /// use tokio::task;
+    ///
+    /// mod module_a {
+    ///     pub fn do_something(handle: tokio::runtime::Handle) {
+    ///         handle.spawn(async {
+    ///             // Some asynchronous task here
+    ///         });
+    ///     }
+    /// }
+    ///
+    /// mod module_b {
+    ///     pub fn do_something_else(rt: &tokio::runtime::Runtime) {
+    ///         rt.spawn(async {
+    ///             // Another asynchronous task here
+    ///         });
+    ///     }
+    /// }
+    ///
+    /// fn main() {
+    ///     let actix_runtime = actix_rt::Runtime::new().unwrap();
+    ///     let tokio_runtime = actix_runtime.tokio_runtime();
+    ///
+    ///     let handle = tokio_runtime.handle().clone();
+    ///
+    ///     module_a::do_something(handle);
+    ///     module_b::do_something_else(tokio_runtime);
+    /// }
+    /// ```
+    ///
+    /// # Returns
+    ///
+    /// An immutable reference to the `tokio::runtime::Runtime` instance associated with this
+    /// `Runtime` instance.
+    ///
+    /// # Note
+    ///
+    /// While this method provides an immutable reference to the Tokio runtime, which is safe to share across threads,
+    /// be aware that spawning blocking tasks on the Tokio runtime could potentially impact the execution
+    /// of the Actix runtime. This is because Tokio is responsible for driving the Actix system,
+    /// and blocking tasks could delay or deadlock other tasks in run loop.
+    pub fn tokio_runtime(&self) -> &tokio::runtime::Runtime {
+        &self.rt
+    }
+
     /// Runs the provided future, blocking the current thread until the future completes.
     ///
     /// This function can be used to synchronously block the current thread until the provided

--- a/actix-rt/src/runtime.rs
+++ b/actix-rt/src/runtime.rs
@@ -94,15 +94,13 @@ impl Runtime {
     ///     }
     /// }
     ///
-    /// fn main() {
-    ///     let actix_runtime = actix_rt::Runtime::new().unwrap();
-    ///     let tokio_runtime = actix_runtime.tokio_runtime();
+    /// let actix_runtime = actix_rt::Runtime::new().unwrap();
+    /// let tokio_runtime = actix_runtime.tokio_runtime();
     ///
-    ///     let handle = tokio_runtime.handle().clone();
+    /// let handle = tokio_runtime.handle().clone();
     ///
-    ///     module_a::do_something(handle);
-    ///     module_b::do_something_else(tokio_runtime);
-    /// }
+    /// module_a::do_something(handle);
+    /// module_b::do_something_else(tokio_runtime);
     /// ```
     ///
     /// # Returns

--- a/actix-rt/src/runtime.rs
+++ b/actix-rt/src/runtime.rs
@@ -76,7 +76,6 @@ impl Runtime {
     ///
     /// ```
     /// use actix_rt::Runtime;
-    /// use tokio::task;
     ///
     /// mod module_a {
     ///     pub fn do_something(handle: tokio::runtime::Handle) {

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -203,6 +203,46 @@ impl SystemRunner {
             .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
     }
 
+    /// Retrieves a reference to the underlying Actix runtime associated with this SystemRunner instance.
+    ///
+    /// The Actix runtime is responsible for managing the event loop for an Actix system and executing asynchronous tasks.
+    /// This method provides access to the runtime, allowing direct interaction with its features.
+    ///
+    /// In a typical use case, you might need to share the same runtime between different
+    /// parts of your project. For example, some components might require a [`actix_rt::Runtime`] to spawn tasks on
+    /// the same runtime.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use actix_rt::SystemRunner;
+    /// use tokio::task;
+    ///
+    /// fn main() {
+    ///     let system_runner = actix_rt::System::new();
+    ///     let actix_runtime = system_runner.runtime();
+    ///
+    ///     // Use the runtime to spawn an async task or perform other operations
+    /// }
+    /// ```
+    ///
+    /// Read more in the documentation for [`actix_rt::Runtime`]
+    ///
+    /// # Returns
+    ///
+    /// An immutable reference to the [`actix_rt::Runtime`] instance associated with this
+    /// [`actix_rt::SystemRunner`] instance.
+    ///
+    /// # Note
+    ///
+    /// While this method provides an immutable reference to the Actix runtime, which is safe to share across threads,
+    /// be aware that spawning blocking tasks on the Actix runtime could potentially impact system performance.
+    /// This is because the Actix runtime is responsible for driving the system,
+    /// and blocking tasks could delay other tasks in the run loop.
+    pub fn runtime(&self) -> &crate::runtime::Runtime {
+        &self.rt
+    }
+
     /// Runs the provided future, blocking the current thread until the future completes.
     #[track_caller]
     #[inline]

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -215,15 +215,10 @@ impl SystemRunner {
     /// # Example
     ///
     /// ```
-    /// use actix_rt::SystemRunner;
-    /// use tokio::task;
+    /// let system_runner = actix_rt::System::new();
+    /// let actix_runtime = system_runner.runtime();
     ///
-    /// fn main() {
-    ///     let system_runner = actix_rt::System::new();
-    ///     let actix_runtime = system_runner.runtime();
-    ///
-    ///     // Use the runtime to spawn an async task or perform other operations
-    /// }
+    /// // Use the runtime to spawn an async task or perform other operations
     /// ```
     ///
     /// Read more in the documentation for [`actix_rt::Runtime`]


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

The `tokio_runtime()` method retrieves a reference to the underlying Tokio runtime associated with an `actix_rt::Runtime` instance. This allows direct interaction with Tokio's features. It is useful for sharing the same runtime between different modules of a project, enabling tasks to be spawned on the same runtime. The method returns an immutable reference to the `tokio::runtime::Runtime`.

Also, as a follow-up feature, `runtime()` is added on `actix_rt::SystemRunner`.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
