### PR TITLE
Update dependencies for RUSTSEC-2023-0052

### DIFF
--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased - 2023-xx-xx
 
 - Minimum supported Rust version (MSRV) is now 1.65.
+- Update tokio-rustls to 0.24
+- Update webpki-roots to 0.25
 
 ## 3.0.4 - 2022-03-15
 

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -58,8 +58,8 @@ tls-openssl = { package = "openssl", version = "0.10.48", optional = true }
 tokio-openssl = { version = "0.6", optional = true }
 
 # rustls
-tokio-rustls = { version = "0.23", optional = true }
-webpki-roots = { version = "0.22", optional = true }
+tokio-rustls = { version = "0.24", optional = true }
+webpki-roots = { version = "0.25", optional = true }
 
 # native-tls
 tokio-native-tls = { version = "0.3", optional = true }
@@ -74,7 +74,7 @@ futures-util = { version = "0.3.17", default-features = false, features = ["sink
 log = "0.4"
 rcgen = "0.10"
 rustls-pemfile = "1"
-tokio-rustls = { version = "0.23", features = ["dangerous_configuration"] }
+tokio-rustls = { version = "0.24", features = ["dangerous_configuration"] }
 trust-dns-resolver = "0.22"
 
 [[example]]


### PR DESCRIPTION
## PR Type

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0052)

## PR Checklist

Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

Due to the fact that it is a security vulnerability, this updates public dependencies (therefore includes breaking changes).  Behavior is mostly the same, except that the error message now calls out that it's actix-tls that doesn't support non-hostnames, rather than rustls (now that that has been fixed).  I also changed the `ErrorKind` to `InvalidInput`, as I believe that to be more accurate.

I understand that it may be desirable for a number of reasons to update and finish https://github.com/actix/actix-net/pull/480 instead of merging this PR (feel free to close), but my personal opinion is that 4.0 is warranted.