### PR TITLE
local-channel: drop futures-util by using future::poll_fn from std

### DIFF
--- a/local-channel/Cargo.toml
+++ b/local-channel/Cargo.toml
@@ -15,8 +15,8 @@ rust-version.workspace = true
 [dependencies]
 futures-core = "0.3.17"
 futures-sink = "0.3.17"
-futures-util = { version = "0.3.17", default-features = false }
 local-waker = "0.1"
 
 [dev-dependencies]
+futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1.23.1", features = ["rt", "macros"] }

--- a/local-channel/src/mpsc.rs
+++ b/local-channel/src/mpsc.rs
@@ -4,6 +4,7 @@ use alloc::{collections::VecDeque, rc::Rc};
 use core::{
     cell::RefCell,
     fmt,
+    future::poll_fn,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -11,7 +12,6 @@ use std::error::Error;
 
 use futures_core::stream::Stream;
 use futures_sink::Sink;
-use futures_util::future::poll_fn;
 use local_waker::LocalWaker;
 
 /// Creates a unbounded in-memory channel with buffered storage.


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

[`future::poll_fn`](https://doc.rust-lang.org/nightly/std/future/fn.poll_fn.html) has been stable since 1.64 in std, so this PR makes use of it instead of the implementation from futures-util