### PR TITLE
Add a builder for arbiter + alive method

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `actix_rt::ArbiterBuilder` to allow user to configure the thread spawned for the arbiter.
+- Add `Arbiter::alive` and `ArbiterHandle::alive` to check is the arbiter is still alive.
 
 ## 2.10.0
 

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `actix_rt::ArbiterBuilder` to allow user to configure the thread spawned for the arbiter.
+
 ## 2.10.0
 
 - Relax `F`'s bound (`Fn => FnOnce`) on `{Arbiter, System}::with_tokio_rt()` functions.

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -71,6 +71,13 @@ impl ArbiterHandle {
         self.spawn(async { f() })
     }
 
+    /// Check if the [Arbiter] is still alive.
+    ///
+    /// Returns false if the [Arbiter] has been dropped, returns true otherwise.
+    pub fn alive(&self) -> bool {
+        !self.tx.is_closed()
+    }
+
     /// Instruct [Arbiter] to stop processing it's event loop.
     ///
     /// Returns true if stop message was sent successfully and false if the [Arbiter] has
@@ -365,6 +372,13 @@ impl Arbiter {
         F: FnOnce() + Send + 'static,
     {
         self.spawn(async { f() })
+    }
+
+    /// Check if the [Arbiter] is still alive.
+    ///
+    /// Returns false if the [Arbiter] has been dropped, returns true otherwise.
+    pub fn alive(&self) -> bool {
+        !self.tx.is_closed()
     }
 
     /// Wait for Arbiter's event loop to complete.

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -67,7 +67,7 @@ pub use tokio::pin;
 use tokio::task::JoinHandle;
 
 pub use self::{
-    arbiter::{Arbiter, ArbiterHandle},
+    arbiter::{Arbiter, ArbiterBuilder, ArbiterHandle},
     runtime::Runtime,
     system::{System, SystemRunner},
 };

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -302,6 +302,28 @@ fn new_arbiter_with_tokio() {
 }
 
 #[test]
+fn arbiter_builder_name() {
+    let _ = System::new();
+
+    let arbiter = Arbiter::builder()
+        .name(|_, _| "test_thread".to_string())
+        .build();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    arbiter.spawn(async move {
+        let current_thread = std::thread::current();
+        let thread_name = current_thread.name().unwrap().to_string();
+        tx.send(thread_name).unwrap();
+    });
+
+    let name = rx.recv().unwrap();
+    assert_eq!(name, "test_thread");
+
+    arbiter.stop();
+    arbiter.join().unwrap();
+}
+
+#[test]
 #[should_panic]
 fn no_system_current_panic() {
     System::current();


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
### Builder
This adds a builder for the arbiter, allowing more customization of the thread used by the arbiter.

The first customizable I added was the name, this allows us to differentiate the different arbiters better since they are not all used for the same purpose.

### Alive
I also added an `alive` method on the arbiter so the caller can try to detect dead arbiters before sending it a future since it consumes it. Otherwise you need to have a clone future which is not good most of the time.
