### PR TITLE
actix-tls: Disable default features for rustls 0.23 via tokio-rustls 0.26

### DIFF
--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -108,7 +108,7 @@ tokio-rustls-025 = { package = "tokio-rustls", version = "0.25", optional = true
 webpki-roots-026 = { package = "webpki-roots", version = "0.26", optional = true } # Also used for rustls v0.23
 
 # rustls v0.23
-tokio-rustls-026 = { package = "tokio-rustls", version = "0.26", optional = true }
+tokio-rustls-026 = { package = "tokio-rustls", version = "0.26", default-features = false, optional = true }
 
 # native root certificates for rustls impls
 rustls-native-certs-06 = { package = "rustls-native-certs", version = "0.6", optional = true }
@@ -127,7 +127,7 @@ futures-util = { version = "0.3.17", default-features = false, features = ["sink
 itertools = "0.12"
 rcgen = "0.12"
 rustls-pemfile = "2"
-tokio-rustls-026 = { package = "tokio-rustls", version = "0.26", features = ["ring"] }
+tokio-rustls-026 = { package = "tokio-rustls", version = "0.26", default-features = false, features = ["ring"] }
 trust-dns-resolver = "0.23"
 
 [[example]]

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -127,7 +127,7 @@ futures-util = { version = "0.3.17", default-features = false, features = ["sink
 itertools = "0.12"
 rcgen = "0.12"
 rustls-pemfile = "2"
-tokio-rustls-026 = { package = "tokio-rustls", version = "0.26", default-features = false, features = ["ring"] }
+tokio-rustls-026 = { package = "tokio-rustls", version = "0.26" }
 trust-dns-resolver = "0.23"
 
 [[example]]

--- a/actix-tls/tests/accept-openssl.rs
+++ b/actix-tls/tests/accept-openssl.rs
@@ -88,7 +88,7 @@ mod danger {
         }
 
         fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-            rustls::crypto::ring::default_provider()
+            rustls::crypto::aws_lc_rs::default_provider()
                 .signature_verification_algorithms
                 .supported_schemes()
         }
@@ -111,7 +111,7 @@ fn rustls_connector(_cert: String, _key: String) -> ClientConfig {
 
 #[actix_rt::test]
 async fn accepts_connections() {
-    tokio_rustls_026::rustls::crypto::ring::default_provider()
+    tokio_rustls_026::rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .unwrap();
 

--- a/actix-tls/tests/accept-openssl.rs
+++ b/actix-tls/tests/accept-openssl.rs
@@ -111,7 +111,7 @@ fn rustls_connector(_cert: String, _key: String) -> ClientConfig {
 
 #[actix_rt::test]
 async fn accepts_connections() {
-    tokio_rustls_026::rustls::crypto::aws_lc_rs::default_provider()
+    tokio_rustls_026::rustls::crypto::ring::default_provider()
         .install_default()
         .unwrap();
 

--- a/actix-tls/tests/accept-rustls.rs
+++ b/actix-tls/tests/accept-rustls.rs
@@ -73,7 +73,7 @@ fn openssl_connector(cert: String, key: String) -> SslConnector {
 
 #[actix_rt::test]
 async fn accepts_connections() {
-    tokio_rustls_026::rustls::crypto::ring::default_provider()
+    tokio_rustls_026::rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .unwrap();
 

--- a/actix-tls/tests/accept-rustls.rs
+++ b/actix-tls/tests/accept-rustls.rs
@@ -73,7 +73,7 @@ fn openssl_connector(cert: String, key: String) -> SslConnector {
 
 #[actix_rt::test]
 async fn accepts_connections() {
-    tokio_rustls_026::rustls::crypto::aws_lc_rs::default_provider()
+    tokio_rustls_026::rustls::crypto::ring::default_provider()
         .install_default()
         .unwrap();
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature?


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
By not enforcing a backend, we allow users to bring their own without requiring they compile one that they aren't using.

This also fixes a panic in accept-rustls due to both ring and aws-lc-rs being enabled for that example
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
