### PR TITLE
Fix logging "starting service:..."

### DIFF
--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -183,11 +183,6 @@ impl ServerInner {
     }
 
     fn run_sync(mut builder: ServerBuilder) -> io::Result<(Self, ServerEventMultiplexer)> {
-        let sockets = mem::take(&mut builder.sockets)
-            .into_iter()
-            .map(|t| (t.0, t.2))
-            .collect();
-
         // Give log information on what runtime will be used.
         let is_actix = actix_rt::System::try_current().is_some();
         let is_tokio = tokio::runtime::Handle::try_current().is_ok();
@@ -206,6 +201,11 @@ impl ServerInner {
                 lst.local_addr()
             );
         }
+
+        let sockets = mem::take(&mut builder.sockets)
+            .into_iter()
+            .map(|t| (t.0, t.2))
+            .collect();
 
         let (waker_queue, worker_handles, accept_handle) = Accept::start(sockets, &builder)?;
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix 


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
When starting a server, message `"starting service: "{}", workers: {}, listening on: {}"` is never logged. 
The issue happens when [mapping](https://github.com/actix/actix-net/blob/912daa3d0aeb2bc09889a6d200ccef839ad6764a/actix-server/src/server.rs#L186) a `builder.sockets` and using `mem::take()` that replaces the original value with default. Since `builder.sockets` is empty, it won't log anything in the [for cycle](https://github.com/actix/actix-net/blob/912daa3d0aeb2bc09889a6d200ccef839ad6764a/actix-server/src/server.rs#L201).  
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
