### PR TITLE
Change with_tokio_rt to accept Arc<Runtime>.

### DIFF
--- a/actix-rt/examples/multi_thread_system.rs
+++ b/actix-rt/examples/multi_thread_system.rs
@@ -10,6 +10,7 @@ fn main() {
             .worker_threads(2)
             .enable_all()
             .build()
+            .map(std::sync::Arc::new)
             .unwrap()
     })
     .block_on(async_main());

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -109,7 +109,7 @@ impl Arbiter {
     #[cfg(not(all(target_os = "linux", feature = "io-uring")))]
     pub fn with_tokio_rt<F>(runtime_factory: F) -> Arbiter
     where
-        F: FnOnce() -> tokio::runtime::Runtime + Send + 'static,
+        F: FnOnce() -> std::sync::Arc<tokio::runtime::Runtime> + Send + 'static,
     {
         let sys = System::current();
         let system_id = sys.id();

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -5,9 +5,9 @@ use std::{
     io,
     pin::Pin,
     sync::atomic::{AtomicUsize, Ordering},
+    sync::Arc,
     task::{Context, Poll},
 };
-
 use futures_core::ready;
 use tokio::sync::{mpsc, oneshot};
 
@@ -48,7 +48,7 @@ impl System {
     /// [tokio-runtime]: tokio::runtime::Runtime
     pub fn with_tokio_rt<F>(runtime_factory: F) -> SystemRunner
     where
-        F: FnOnce() -> tokio::runtime::Runtime,
+        F: FnOnce() -> Arc<tokio::runtime::Runtime>,
     {
         let (stop_tx, stop_rx) = oneshot::channel();
         let (sys_tx, sys_rx) = mpsc::unbounded_channel();
@@ -87,7 +87,7 @@ impl System {
     #[doc(hidden)]
     pub fn with_tokio_rt<F>(_: F) -> SystemRunner
     where
-        F: FnOnce() -> tokio::runtime::Runtime,
+        F: FnOnce() -> Arc<tokio::runtime::Runtime>,
     {
         unimplemented!("System::with_tokio_rt is not implemented for io-uring feature yet")
     }

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -6,7 +6,7 @@ use std::{
 use actix_rt::{task::JoinError, Arbiter, System};
 #[cfg(not(feature = "io-uring"))]
 use {
-    std::{sync::mpsc::channel, thread},
+    std::{sync::Arc, sync::mpsc::channel, thread},
     tokio::sync::oneshot,
 };
 
@@ -250,6 +250,7 @@ fn new_system_with_tokio() {
             .on_thread_start(|| {})
             .on_thread_stop(|| {})
             .build()
+            .map(Arc::new)
             .unwrap()
     })
     .block_on(async {
@@ -282,6 +283,7 @@ fn new_arbiter_with_tokio() {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
+            .map(Arc::new)
             .unwrap()
     });
 

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -426,6 +426,7 @@ impl ServerWorker {
                             .enable_all()
                             .max_blocking_threads(config.max_blocking_threads)
                             .build()
+                            .map(Arc::new)
                             .unwrap()
                     })
                 };


### PR DESCRIPTION
This allows to share tokio runtimes across different sub-systems inside your application.

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature, Refactor

https://github.com/actix/actix-net/issues/580

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

The current signature of https://docs.rs/actix-rt/latest/actix_rt/struct.System.html#method.with_tokio_rt expects a `Runtime`. It would be better if I can supply an Arc<Runtime> instead. The reason being that is that in a bigger application we have multiple systems trying to leverage tokio. With the given API I still need to create a separate runtime for actix. Having the same runtime is helpful for better control over CPU resources as there aren't `n` runtimes competing for CPU time.

FWIW this is a breaking change so if there alternative ways to achieve this I'm happy to give those a try too.
