### PR TITLE
Remove need for paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "paste",
  "pin-project-lite",
 ]
 

--- a/actix-service/Cargo.toml
+++ b/actix-service/Cargo.toml
@@ -12,7 +12,6 @@ rust-version.workspace = true
 
 [dependencies]
 futures-core = { version = "0.3.17", default-features = false }
-paste = "1"
 pin-project-lite = "0.2"
 
 [dev-dependencies]

--- a/actix-service/src/boxed.rs
+++ b/actix-service/src/boxed.rs
@@ -3,36 +3,38 @@
 use alloc::{boxed::Box, rc::Rc};
 use core::{future::Future, pin::Pin};
 
-use paste::paste;
-
 use crate::{Service, ServiceFactory};
 
 /// A boxed future with no send bound or lifetime parameters.
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
-macro_rules! service_object {
-    ($name: ident, $type: tt, $fn_name: ident) => {
-        paste! {
-            #[doc = "Type alias for service trait object using `" $type "`."]
-            pub type $name<Req, Res, Err> = $type<
-                dyn Service<Req, Response = Res, Error = Err, Future = BoxFuture<Result<Res, Err>>>,
-            >;
+/// Type alias for service trait object using [`Box`].
+pub type BoxService<Req, Res, Err> =
+    Box<dyn Service<Req, Response = Res, Error = Err, Future = BoxFuture<Result<Res, Err>>>>;
 
-            #[doc = "Wraps service as a trait object using [`" $name "`]."]
-            pub fn $fn_name<S, Req>(service: S) -> $name<Req, S::Response, S::Error>
-            where
-                S: Service<Req> + 'static,
-                Req: 'static,
-                S::Future: 'static,
-            {
-                $type::new(ServiceWrapper::new(service))
-            }
-        }
-    };
+/// Wraps service as a trait object using [`BoxService`].
+pub fn service<S, Req>(service: S) -> BoxService<Req, S::Response, S::Error>
+where
+    S: Service<Req> + 'static,
+    Req: 'static,
+    S::Future: 'static,
+{
+    Box::new(ServiceWrapper::new(service))
 }
 
-service_object!(BoxService, Box, service);
-service_object!(RcService, Rc, rc_service);
+/// Type alias for service trait object using [`Rc`].
+pub type RcService<Req, Res, Err> =
+    Rc<dyn Service<Req, Response = Res, Error = Err, Future = BoxFuture<Result<Res, Err>>>>;
+
+/// Wraps service as a trait object using [`RcService`].
+pub fn rc_service<S, Req>(service: S) -> RcService<Req, S::Response, S::Error>
+where
+    S: Service<Req> + 'static,
+    Req: 'static,
+    S::Future: 'static,
+{
+    Rc::new(ServiceWrapper::new(service))
+}
 
 struct ServiceWrapper<S> {
     inner: S,


### PR DESCRIPTION
The easiest way to fix #648 for now is to remove the need for paste entirely. It was only used in one spot and the macro was only saving a small amount of code in a file which changes very rarely.

So this PR replaces the macro with equivalent code, which as a side effect will maybe very slightly improve compile times a little bit? 😅 

Note that paste is still in the dependency tree via `aws-lc-rs`, but [they are working to get rid of it](https://github.com/aws/aws-lc-rs/issues/722)