### PR TITLE
chore: Bump up MSRV to 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.80"
 
 [patch.crates-io]
 actix-codec = { path = "actix-codec" }

--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 0.5.2
 

--- a/actix-macros/CHANGES.md
+++ b/actix-macros/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 0.2.4
 

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 2.10.0
 

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -5,7 +5,7 @@
 ## 2.6.0
 
 - Add `ServerBuilder::shutdown_signal()` method.
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 2.5.1
 

--- a/actix-service/CHANGES.md
+++ b/actix-service/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 2.0.3
 

--- a/actix-tls/CHANGES.md
+++ b/actix-tls/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 3.4.0
 

--- a/actix-tracing/CHANGES.md
+++ b/actix-tracing/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 0.1.0
 

--- a/actix-utils/CHANGES.md
+++ b/actix-utils/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 3.0.1
 

--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 1.4.0
 

--- a/local-channel/CHANGES.md
+++ b/local-channel/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 0.1.5
 

--- a/local-waker/CHANGES.md
+++ b/local-waker/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minimum supported Rust version (MSRV) is now 1.74.
+- Minimum supported Rust version (MSRV) is now 1.80.
 
 ## 0.1.4
 


### PR DESCRIPTION
## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Other

## PR Checklist

Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

Bump up MSRV to 1.80 due to a transitive dependency: `error: package `rayon-core v1.13.0` cannot be built because it requires rustc 1.80 or newer, while the currently active rustc version is 1.74.0`

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
