### PR TITLE
Switch `serde` dependency to `serde_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ version = "1.4.0"
 dependencies = [
  "ahash",
  "bytes",
- "serde",
+ "serde_core",
  "serde_json",
  "static_assertions",
 ]
@@ -1849,18 +1849,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.75.
+- Switch `serde` to `serde_core`
 
 ## 1.4.0
 

--- a/bytestring/Cargo.toml
+++ b/bytestring/Cargo.toml
@@ -16,12 +16,15 @@ allowed_external_types = ["bytes::*", "serde::*"]
 
 [dependencies]
 bytes = { version = "1.2", default-features = false }
-serde = { version = "1", optional = true }
+serde_core = { version = "1.0.221", optional = true }
 
 [dev-dependencies]
 ahash = { version = "0.8", default-features = false }
 serde_json = "1"
 static_assertions = "1.1"
+
+[features]
+serde = ["dep:serde_core"]
 
 [lints]
 workspace = true

--- a/bytestring/src/lib.rs
+++ b/bytestring/src/lib.rs
@@ -275,7 +275,7 @@ impl fmt::Display for ByteString {
 mod serde {
     use alloc::string::String;
 
-    use serde::{
+    use serde_core::{
         de::{Deserialize, Deserializer},
         ser::{Serialize, Serializer},
     };
@@ -304,7 +304,7 @@ mod serde {
 
     #[cfg(test)]
     mod serde_impl_tests {
-        use serde::de::DeserializeOwned;
+        use serde_core::de::DeserializeOwned;
         use static_assertions::assert_impl_all;
 
         use super::*;


### PR DESCRIPTION
## PR Type

Other

## PR Checklist

Check your PR fulfills the following:

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

[serde_core](https://crates.io/crates/serde_core) has just been released. Crates that don't depend on serde derive macros should use it instead of `serde`, as it speeds up compile times by having the build for the crate itself be independent from `serde-derive` (in case it were to be enabled by some other crate). See the serde_core docs for more info.

On my Ryzen 5 5500U, the clean release build time for just `bytestring` in a project containing `bytestring` with the `serde` feature enabled, and `serde` with the `derive` feature enabled, went from 5.32s to 3.08s.
