### PR TITLE
perf(bytestring): improve `From<ByteString> for String` performance

### DIFF
--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Minimum supported Rust version (MSRV) is now 1.88.
+- Improve `From<ByteString> for String` performance.
 
 ## 1.5.0
 

--- a/bytestring/src/lib.rs
+++ b/bytestring/src/lib.rs
@@ -6,11 +6,7 @@
 
 extern crate alloc;
 
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{borrow::Borrow, fmt, hash, ops, str};
 
 use bytes::Bytes;
@@ -189,7 +185,7 @@ impl From<Box<str>> for ByteString {
 impl From<ByteString> for String {
     #[inline]
     fn from(value: ByteString) -> Self {
-        value.to_string()
+        String::from_utf8(value.0.into()).expect("ByteString invariant violated")
     }
 }
 


### PR DESCRIPTION
## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

INSERT_PR_TYPE

## PR Checklist

Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
`ToString` requires an extra allocation when converting: https://github.com/rust-lang/rust/blob/c7c14d4fb0310429e05e1a24dcf879053ee25b09/library/alloc/src/string.rs#L2911

Since we assume the value is UTF-8, it should be okay to use `String::from_utf8` just like other convension.

Verified the effect roughly with:
```rs
const STRING_LEN: usize = 65536;

fn owned_bytestring() -> ByteString {
    ByteString::from("a".repeat(STRING_LEN))
}

fn bench_string_conversion(c: &mut Criterion) {
    c.bench_function("bytestring_into_string_from_owned_buffer", |b| {
        b.iter_batched(
            owned_bytestring,
            |value| black_box(String::from(value)),
            BatchSize::SmallInput,
        );
    });
}
```