### PR TITLE
perf(bytestring): micro-improve performance against ASCII conv

### DIFF
--- a/bytestring/CHANGES.md
+++ b/bytestring/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Minimum supported Rust version (MSRV) is now 1.88.
 - Improve `From<ByteString> for String` performance.
+- Improve ASCII `TryFrom` conversions performance.
 
 ## 1.5.0
 

--- a/bytestring/src/lib.rs
+++ b/bytestring/src/lib.rs
@@ -195,6 +195,10 @@ impl TryFrom<&[u8]> for ByteString {
 
     #[inline]
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.is_ascii() {
+            return Ok(ByteString(Bytes::copy_from_slice(value)));
+        }
+
         let _ = str::from_utf8(value)?;
         Ok(ByteString(Bytes::copy_from_slice(value)))
     }
@@ -205,6 +209,10 @@ impl TryFrom<Vec<u8>> for ByteString {
 
     #[inline]
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.is_ascii() {
+            return Ok(ByteString(Bytes::from(value)));
+        }
+
         let buf = String::from_utf8(value).map_err(|err| err.utf8_error())?;
         Ok(ByteString(Bytes::from(buf)))
     }
@@ -215,6 +223,10 @@ impl TryFrom<Bytes> for ByteString {
 
     #[inline]
     fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        if value.is_ascii() {
+            return Ok(ByteString(value));
+        }
+
         let _ = str::from_utf8(value.as_ref())?;
         Ok(ByteString(value))
     }
@@ -225,6 +237,10 @@ impl TryFrom<bytes::BytesMut> for ByteString {
 
     #[inline]
     fn try_from(value: bytes::BytesMut) -> Result<Self, Self::Error> {
+        if value.is_ascii() {
+            return Ok(ByteString(value.freeze()));
+        }
+
         let _ = str::from_utf8(&value)?;
         Ok(ByteString(value.freeze()))
     }
@@ -413,7 +429,10 @@ mod test {
 
     #[test]
     fn try_from_slice() {
+        let heart = "\u{1f496}";
         let _ = ByteString::try_from(b"nice bytes").unwrap();
+        assert_eq!(ByteString::try_from(heart.as_bytes()).unwrap(), heart);
+        ByteString::try_from(&[0, 159, 146, 150][..]).unwrap_err();
     }
 
     #[test]
@@ -432,12 +451,22 @@ mod test {
 
     #[test]
     fn try_from_bytes() {
+        let heart = "\u{1f496}";
         let _ = ByteString::try_from(Bytes::from_static(b"nice bytes")).unwrap();
+        assert_eq!(
+            ByteString::try_from(Bytes::from_static(heart.as_bytes())).unwrap(),
+            heart
+        );
     }
 
     #[test]
     fn try_from_bytes_mut() {
+        let heart = "\u{1f496}";
         let _ = ByteString::try_from(bytes::BytesMut::from(&b"nice bytes"[..])).unwrap();
+        assert_eq!(
+            ByteString::try_from(bytes::BytesMut::from(heart.as_bytes())).unwrap(),
+            heart
+        );
     }
 
     #[test]


### PR DESCRIPTION
## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

INSERT_PR_TYPE

## PR Checklist

Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Another one, improve performance against ASCII to avoid UTF-8 convension. On local benchmarks, it shows roughly 20-30% improvement.
Since I assume most values would be ASCII, I expect this would be benefitical for most usecases.