### PR TITLE
feat: remove experimental io-uring support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,12 +4,12 @@ lint-all = "clippy --workspace --all-features --tests --examples --bins -- -Dcli
 
 # just check the library (without dev deps)
 ci-check-min = "hack --workspace check --no-default-features"
-ci-check-lib = "hack --workspace --feature-powerset --depth=2 --exclude-features=io-uring check"
+ci-check-lib = "hack --workspace --feature-powerset --depth=2 check"
 ci-check-lib-linux = "hack --workspace --feature-powerset --depth=2 check"
 
 # check everything
-ci-check = "hack --workspace --feature-powerset --depth=2 --exclude-features=io-uring check --tests --examples"
+ci-check = "hack --workspace --feature-powerset --depth=2 check --tests --examples"
 ci-check-linux = "hack --workspace --feature-powerset --depth=2 check --tests --examples"
 
-# tests avoiding io-uring feature
-ci-test = "hack --feature-powerset --depth=2 --exclude-features=io-uring test --lib --tests --no-fail-fast -- --nocapture"
+# test workspace code
+ci-test = "hack --feature-powerset --depth=2 test --lib --tests --no-fail-fast -- --nocapture"

--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -95,19 +95,6 @@ jobs:
       - name: tests
         run: just test
 
-      # TODO: re-instate some io-uring tests PRs
-      # - name: tests
-      #   if: matrix.target.os == 'ubuntu-latest'
-      #   run: >-
-      #     sudo bash -c "
-      #     ulimit -Sl 512
-      #     && ulimit -Hl 512
-      #     && PATH=$PATH:/usr/share/rust/.cargo/bin
-      #     && RUSTUP_TOOLCHAIN=${{ matrix.version }} cargo ci-test-rustls-020
-      #     && RUSTUP_TOOLCHAIN=${{ matrix.version }} cargo ci-test-rustls-021
-      #     && RUSTUP_TOOLCHAIN=${{ matrix.version }} cargo ci-test-linux
-      #     "
-
       - name: CI cache clean
         run: cargo-ci-cache-clean
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "actix-codec"
 version = "0.5.2"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytes",
  "criterion",
  "futures-core",
@@ -39,7 +39,6 @@ dependencies = [
  "actix-macros",
  "futures-core",
  "tokio",
- "tokio-uring",
 ]
 
 [[package]]
@@ -55,10 +54,9 @@ dependencies = [
  "futures-util",
  "mio",
  "pretty_env_logger",
- "socket2 0.6.5",
+ "socket2",
  "static_assertions",
  "tokio",
- "tokio-uring",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -228,12 +226,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -972,22 +964,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.5",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -1280,7 +1262,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1560,7 +1542,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -1642,7 +1624,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1838,7 +1820,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -1851,7 +1833,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1981,16 +1963,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -2051,7 +2023,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2195,7 +2167,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2294,20 +2266,6 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-uring"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748482e3e13584a34664a710168ad5068e8cb1d968aa4ffa887e83ca6dd27967"
-dependencies = [
- "futures-util",
- "io-uring",
- "libc",
- "slab",
- "socket2 0.4.10",
- "tokio",
 ]
 
 [[package]]
@@ -2628,7 +2586,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2911,7 +2869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.13.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "actix-codec",
  "actix-rt",

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -4,6 +4,7 @@
 
 ## 2.12.0
 
+- Remove experimental `io-uring` support.
 - Minimum supported Rust version (MSRV) is now 1.88.
 - Add `SystemRunner::stop_future` and `SystemRunner::into_parts` for awaiting system stop inside `block_on`.
 - Allow `{System, Arbiter}::with_tokio_rt` to accept shared Tokio runtimes (e.g. `Arc<tokio::runtime::Runtime>` or `&'static tokio::runtime::Runtime`).

--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.12.0
+
 - Minimum supported Rust version (MSRV) is now 1.88.
 - Add `SystemRunner::stop_future` and `SystemRunner::into_parts` for awaiting system stop inside `block_on`.
 - Allow `{System, Arbiter}::with_tokio_rt` to accept shared Tokio runtimes (e.g. `Arc<tokio::runtime::Runtime>` or `&'static tokio::runtime::Runtime`).

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-rt"
-version = "2.11.0"
+version = "2.12.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>", "Rob Ede <robjtede@icloud.com>"]
 description = "Tokio-based single-threaded async runtime for the Actix ecosystem"
 categories = ["network-programming", "asynchronous"]

--- a/actix-rt/Cargo.toml
+++ b/actix-rt/Cargo.toml
@@ -17,17 +17,12 @@ allowed_external_types = ["actix_macros::*", "tokio::*"]
 [features]
 default = ["macros"]
 macros = ["actix-macros"]
-io-uring = ["tokio-uring"]
 
 [dependencies]
 actix-macros = { version = "0.2.3", optional = true }
 
 futures-core = { version = "0.3", default-features = false }
 tokio = { version = "1.44.2", features = ["rt", "io-util", "net", "parking_lot", "signal", "sync", "time"] }
-
-# runtime for `io-uring` feature
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio-uring = { version = "0.5", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.44.2", features = ["full"] }

--- a/actix-rt/README.md
+++ b/actix-rt/README.md
@@ -3,11 +3,11 @@
 > Tokio-based single-threaded async runtime for the Actix ecosystem.
 
 [![crates.io](https://img.shields.io/crates/v/actix-rt?label=latest)](https://crates.io/crates/actix-rt)
-[![Documentation](https://docs.rs/actix-rt/badge.svg?version=2.11.0)](https://docs.rs/actix-rt/2.11.0)
+[![Documentation](https://docs.rs/actix-rt/badge.svg?version=2.12.0)](https://docs.rs/actix-rt/2.12.0)
 [![Version](https://img.shields.io/badge/rustc-1.88+-ab6000.svg)](https://blog.rust-lang.org/2020/03/12/Rust-1.46.html)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-rt.svg)
 <br />
-[![dependency status](https://deps.rs/crate/actix-rt/2.11.0/status.svg)](https://deps.rs/crate/actix-rt/2.11.0)
+[![dependency status](https://deps.rs/crate/actix-rt/2.12.0/status.svg)](https://deps.rs/crate/actix-rt/2.12.0)
 ![Download](https://img.shields.io/crates/d/actix-rt.svg)
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/WghFtEH6Hb)
 

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -95,7 +95,6 @@ impl Arbiter {
     ///
     /// # Panics
     /// Panics if a [System] is not registered on the current thread.
-    #[cfg(not(all(target_os = "linux", feature = "io-uring")))]
     #[allow(clippy::new_without_default)]
     pub fn new() -> Arbiter {
         Self::with_tokio_rt(|| {
@@ -111,7 +110,6 @@ impl Arbiter {
     ///
     /// [tokio-runtime]: tokio::runtime::Runtime
     /// [`Runtime`]: crate::Runtime
-    #[cfg(not(all(target_os = "linux", feature = "io-uring")))]
     pub fn with_tokio_rt<F, R>(runtime_factory: F) -> Arbiter
     where
         F: FnOnce() -> R + Send + 'static,
@@ -147,56 +145,6 @@ impl Arbiter {
 
                     // run arbiter event processing loop
                     rt.block_on(ArbiterRunner { rx });
-
-                    // deregister arbiter
-                    let _ = System::current()
-                        .tx()
-                        .send(SystemCommand::DeregisterArbiter(arb_id));
-                }
-            })
-            .unwrap_or_else(|err| panic!("Cannot spawn Arbiter's thread: {name:?}: {err:?}"));
-
-        ready_rx.recv().unwrap();
-
-        Arbiter { tx, thread_handle }
-    }
-
-    /// Spawn a new Arbiter thread and start its event loop with `tokio-uring` runtime.
-    ///
-    /// # Panics
-    /// Panics if a [System] is not registered on the current thread.
-    #[cfg(all(target_os = "linux", feature = "io-uring"))]
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Arbiter {
-        let sys = System::current();
-        let system_id = sys.id();
-        let arb_id = COUNT.fetch_add(1, Ordering::Relaxed);
-
-        let name = format!("actix-rt|system:{system_id}|arbiter:{arb_id}");
-        let (tx, rx) = mpsc::unbounded_channel();
-
-        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
-
-        let thread_handle = thread::Builder::new()
-            .name(name.clone())
-            .spawn({
-                let tx = tx.clone();
-                move || {
-                    let hnd = ArbiterHandle::new(tx);
-
-                    System::set_current(sys);
-
-                    HANDLE.with(|cell| *cell.borrow_mut() = Some(hnd.clone()));
-
-                    // register arbiter
-                    let _ = System::current()
-                        .tx()
-                        .send(SystemCommand::RegisterArbiter(arb_id, hnd));
-
-                    ready_tx.send(()).unwrap();
-
-                    // run arbiter event processing loop
-                    tokio_uring::start(ArbiterRunner { rx });
 
                     // deregister arbiter
                     let _ = System::current()

--- a/actix-rt/src/lib.rs
+++ b/actix-rt/src/lib.rs
@@ -33,20 +33,9 @@
 //! arbiter.join().unwrap();
 //! ```
 //!
-//! # `io-uring` Support
-//!
-//! There is experimental support for using io-uring with this crate by enabling the
-//! `io-uring` feature. For now, it is semver exempt.
-//!
-//! Note that there are currently some unimplemented parts of using `actix-rt` with `io-uring`.
-//! In particular, when running a `System`, only `System::block_on` is supported.
-
 #![allow(clippy::type_complexity)]
 #![doc(html_logo_url = "https://actix.rs/img/logo.png")]
 #![doc(html_favicon_url = "https://actix.rs/favicon.ico")]
-
-#[cfg(all(not(target_os = "linux"), feature = "io-uring"))]
-compile_error!("io_uring is a linux only feature.");
 
 use std::future::Future;
 

--- a/actix-rt/src/system.rs
+++ b/actix-rt/src/system.rs
@@ -29,7 +29,6 @@ pub struct System {
     arbiter_handle: ArbiterHandle,
 }
 
-#[cfg(not(feature = "io-uring"))]
 impl System {
     /// Create a new system.
     ///
@@ -73,30 +72,6 @@ impl System {
         rt.spawn(sys_ctrl);
 
         SystemRunner { rt, stop_rx }
-    }
-}
-
-#[cfg(feature = "io-uring")]
-impl System {
-    /// Create a new system.
-    ///
-    /// # Panics
-    /// Panics if underlying Tokio runtime can not be created.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> SystemRunner {
-        SystemRunner
-    }
-
-    /// Create a new System using the [Tokio Runtime](tokio-runtime) returned from a closure.
-    ///
-    /// [tokio-runtime]: tokio::runtime::Runtime
-    #[doc(hidden)]
-    pub fn with_tokio_rt<F, R>(_: F) -> SystemRunner
-    where
-        F: FnOnce() -> R,
-        R: Into<crate::runtime::Runtime>,
-    {
-        unimplemented!("System::with_tokio_rt is not implemented for io-uring feature yet")
     }
 }
 
@@ -178,7 +153,6 @@ impl System {
 }
 
 /// Runner that keeps a [System]'s event loop alive until stop message is received.
-#[cfg(not(feature = "io-uring"))]
 #[must_use = "A SystemRunner does nothing unless `run` is called."]
 #[derive(Debug)]
 pub struct SystemRunner {
@@ -186,7 +160,6 @@ pub struct SystemRunner {
     stop_rx: watch::Receiver<Option<i32>>,
 }
 
-#[cfg(not(feature = "io-uring"))]
 impl SystemRunner {
     /// Starts event loop and will return once [System] is [stopped](System::stop).
     pub fn run(self) -> io::Result<()> {
@@ -285,60 +258,6 @@ impl SystemRunner {
     }
 }
 
-/// Runner that keeps a [System]'s event loop alive until stop message is received.
-#[cfg(feature = "io-uring")]
-#[must_use = "A SystemRunner does nothing unless `run` is called."]
-#[derive(Debug)]
-pub struct SystemRunner;
-
-#[cfg(feature = "io-uring")]
-impl SystemRunner {
-    /// Starts event loop and will return once [System] is [stopped](System::stop).
-    pub fn run(self) -> io::Result<()> {
-        unimplemented!("SystemRunner::run is not implemented for io-uring feature yet");
-    }
-
-    /// Runs the event loop until [stopped](System::stop_with_code), returning the exit code.
-    pub fn run_with_code(self) -> io::Result<i32> {
-        unimplemented!("SystemRunner::run_with_code is not implemented for io-uring feature yet");
-    }
-
-    /// Returns a future that resolves with the system's exit code when it is stopped.
-    pub fn stop_future(&self) -> SystemStop {
-        unimplemented!("SystemRunner::stop_future is not implemented for io-uring feature yet");
-    }
-
-    /// Splits this runner into its runtime and a future that resolves when the system stops.
-    pub fn into_parts(self) -> (crate::runtime::Runtime, SystemStop) {
-        unimplemented!("SystemRunner::into_parts is not implemented for io-uring feature yet");
-    }
-
-    /// Runs the provided future, blocking the current thread until the future completes.
-    #[inline]
-    pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
-        tokio_uring::start(async move {
-            let (stop_tx, stop_rx) = watch::channel(None);
-            let (sys_tx, sys_rx) = mpsc::unbounded_channel();
-
-            let sys_arbiter = Arbiter::in_new_system();
-            let system = System::construct(sys_tx, sys_arbiter.clone());
-
-            system
-                .tx()
-                .send(SystemCommand::RegisterArbiter(usize::MAX, sys_arbiter))
-                .unwrap();
-
-            // init background system arbiter
-            let sys_ctrl = SystemController::new(sys_rx, stop_tx);
-            tokio_uring::spawn(sys_ctrl);
-
-            let res = fut.await;
-            drop(stop_rx);
-            res
-        })
-    }
-}
-
 /// Future that resolves with the exit code when a [`System`] is stopped.
 #[must_use = "SystemStop does nothing unless polled or awaited."]
 pub struct SystemStop {
@@ -346,7 +265,6 @@ pub struct SystemStop {
 }
 
 impl SystemStop {
-    #[cfg_attr(feature = "io-uring", allow(dead_code))]
     fn new(stop_rx: watch::Receiver<Option<i32>>) -> Self {
         Self {
             inner: Box::pin(wait_for_stop(stop_rx)),
@@ -362,7 +280,6 @@ impl Future for SystemStop {
     }
 }
 
-#[cfg_attr(feature = "io-uring", allow(dead_code))]
 async fn wait_for_stop(mut stop_rx: watch::Receiver<Option<i32>>) -> io::Result<i32> {
     loop {
         if let Some(code) = *stop_rx.borrow() {

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -2,15 +2,13 @@
 
 use std::{
     future::Future,
+    sync::mpsc::channel,
+    thread,
     time::{Duration, Instant},
 };
 
 use actix_rt::{task::JoinError, Arbiter, System};
-#[cfg(not(feature = "io-uring"))]
-use {
-    std::{sync::mpsc::channel, thread},
-    tokio::sync::oneshot,
-};
+use tokio::sync::oneshot;
 
 #[test]
 fn await_for_timer() {
@@ -25,7 +23,6 @@ fn await_for_timer() {
     );
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn run_with_code() {
     let sys = System::new();
@@ -34,7 +31,6 @@ fn run_with_code() {
     assert_eq!(exit_code, 42);
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn stop_future_resolves() {
     let sys = System::new();
@@ -48,7 +44,6 @@ fn stop_future_resolves() {
     assert_eq!(exit_code, 7);
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn into_parts_stop_future_resolves() {
     let sys = System::new();
@@ -144,10 +139,6 @@ fn wait_for_spawns() {
     assert!(rt.block_on(handle).is_err());
 }
 
-// Temporary disabled tests for io-uring feature.
-// They should be enabled when possible.
-
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn arbiter_spawn_fn_runs() {
     let _ = System::new();
@@ -164,7 +155,6 @@ fn arbiter_spawn_fn_runs() {
     arbiter.join().unwrap();
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn arbiter_handle_spawn_fn_runs() {
     let sys = System::new();
@@ -187,7 +177,6 @@ fn arbiter_handle_spawn_fn_runs() {
     sys.run().unwrap();
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn arbiter_drop_no_panic_fn() {
     let _ = System::new();
@@ -199,7 +188,6 @@ fn arbiter_drop_no_panic_fn() {
     arbiter.join().unwrap();
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn arbiter_drop_no_panic_fut() {
     let _ = System::new();
@@ -211,7 +199,6 @@ fn arbiter_drop_no_panic_fut() {
     arbiter.join().unwrap();
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn system_arbiter_spawn() {
     let runner = System::new();
@@ -242,7 +229,6 @@ fn system_arbiter_spawn() {
     thread.join().unwrap();
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn system_stop_stops_arbiters() {
     let sys = System::new();
@@ -265,7 +251,6 @@ fn system_stop_stops_arbiters() {
     arb.join().unwrap();
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn new_system_with_tokio() {
     let (tx, rx) = channel();
@@ -298,7 +283,6 @@ fn new_system_with_tokio() {
     assert_eq!(rx.recv().unwrap(), 42);
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn new_system_with_shared_tokio_runtime() {
     use std::sync::Arc;
@@ -335,7 +319,6 @@ fn new_system_with_shared_tokio_runtime() {
     assert_eq!(rx.recv().unwrap(), 7);
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn new_system_with_static_tokio_runtime() {
     use std::sync::OnceLock;
@@ -357,7 +340,6 @@ fn new_system_with_static_tokio_runtime() {
     assert_eq!(res, 7);
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn new_arbiter_with_tokio() {
     use std::sync::{
@@ -390,7 +372,6 @@ fn new_arbiter_with_tokio() {
     assert!(!counter.load(Ordering::SeqCst));
 }
 
-#[cfg(not(feature = "io-uring"))]
 #[test]
 fn new_arbiter_with_shared_tokio_runtime() {
     use std::sync::{
@@ -472,33 +453,5 @@ fn spawn_local() {
         fn h<F: Future<Output = Result<R, JoinError>>, R>(_f: F) {}
         h(actix_rt::spawn(async {}));
         h(actix_rt::spawn(async { 1 }));
-    })
-}
-
-#[cfg(all(target_os = "linux", feature = "io-uring"))]
-#[test]
-fn tokio_uring_arbiter() {
-    System::new().block_on(async {
-        let (tx, rx) = std::sync::mpsc::channel();
-
-        Arbiter::new().spawn(async move {
-            let handle = actix_rt::spawn(async move {
-                let f = tokio_uring::fs::File::create("test.txt").await.unwrap();
-                let buf = b"Hello World!";
-
-                let (res, _) = f.write_all_at(&buf[..], 0).await;
-                assert!(res.is_ok());
-
-                f.sync_all().await.unwrap();
-                f.close().await.unwrap();
-
-                std::fs::remove_file("test.txt").unwrap();
-            });
-
-            handle.await.unwrap();
-            tx.send(true).unwrap();
-        });
-
-        assert!(rx.recv().unwrap());
     })
 }

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -4,7 +4,7 @@
 
 ## 2.8.0
 
-- No significant changes since `2.7.0`.
+- Remove experimental `io-uring` support.
 
 ## 2.7.0
 

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.8.0
+
+- No significant changes since `2.7.0`.
+
 ## 2.7.0
 
 - Add `ServerBuilder::graceful_shutdown_signal()` to propagate graceful shutdown to services.

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -20,7 +20,6 @@ allowed_external_types = ["tokio::*"]
 
 [features]
 default = []
-io-uring = ["tokio-uring", "actix-rt/io-uring"]
 
 [dependencies]
 actix-rt = { version = "2.10", default-features = false }
@@ -32,10 +31,6 @@ mio = { version = "1", features = ["os-poll", "net"] }
 socket2 = "0.6"
 tokio = { version = "1.44.2", features = ["sync"] }
 tracing = { version = "0.1.30", default-features = false, features = ["log"] }
-
-# runtime for `io-uring` feature
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio-uring = { version = "0.5", optional = true }
 
 [dev-dependencies]
 actix-codec = "0.5"

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-server"
-version = "2.7.0"
+version = "2.8.0"
 authors = [
   "Nikolay Kim <fafhrd91@gmail.com>",
   "Rob Ede <robjtede@icloud.com>",

--- a/actix-server/README.md
+++ b/actix-server/README.md
@@ -5,11 +5,11 @@
 <!-- prettier-ignore-start -->
 
 [![crates.io](https://img.shields.io/crates/v/actix-server?label=latest)](https://crates.io/crates/actix-server)
-[![Documentation](https://docs.rs/actix-server/badge.svg?version=2.7.0)](https://docs.rs/actix-server/2.7.0)
+[![Documentation](https://docs.rs/actix-server/badge.svg?version=2.8.0)](https://docs.rs/actix-server/2.8.0)
 [![Version](https://img.shields.io/badge/rustc-1.88+-ab6000.svg)](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-server.svg)
 <br />
-[![Dependency Status](https://deps.rs/crate/actix-server/2.7.0/status.svg)](https://deps.rs/crate/actix-server/2.7.0)
+[![Dependency Status](https://deps.rs/crate/actix-server/2.8.0/status.svg)](https://deps.rs/crate/actix-server/2.8.0)
 ![Download](https://img.shields.io/crates/d/actix-server.svg)
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -296,19 +296,6 @@ impl ServerWorker {
         // service factories initialization channel
         let (factory_tx, factory_rx) = std::sync::mpsc::sync_channel::<io::Result<()>>(1);
 
-        // outline of following code:
-        //
-        // if system exists
-        //   if uring enabled
-        //     start arbiter using uring method
-        //   else
-        //     start arbiter with regular tokio
-        // else
-        //   if uring enabled
-        //     start uring in spawned thread
-        //   else
-        //     start regular tokio in spawned thread
-
         // every worker runs in it's own thread and tokio runtime.
         // use a custom tokio runtime builder to change the settings of runtime.
 
@@ -381,39 +368,19 @@ impl ServerWorker {
                             worker_stopped_rx.await.unwrap();
                         };
 
-                        #[cfg(all(target_os = "linux", feature = "io-uring"))]
-                        {
-                            // TODO: pass max blocking thread config when tokio-uring enable configuration
-                            // on building runtime.
-                            let _ = config.max_blocking_threads;
-                            tokio_uring::start(worker_fut);
-                        }
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .max_blocking_threads(config.max_blocking_threads)
+                            .build()
+                            .unwrap();
 
-                        #[cfg(not(all(target_os = "linux", feature = "io-uring")))]
-                        {
-                            let rt = tokio::runtime::Builder::new_current_thread()
-                                .enable_all()
-                                .max_blocking_threads(config.max_blocking_threads)
-                                .build()
-                                .unwrap();
-
-                            rt.block_on(ls.run_until(worker_fut));
-                        }
+                        rt.block_on(ls.run_until(worker_fut));
                     })
                     .expect("cannot spawn server worker thread");
             }
 
             // with actix system
             (Some(_sys), _) => {
-                #[cfg(all(target_os = "linux", feature = "io-uring"))]
-                let arbiter = {
-                    // TODO: pass max blocking thread config when tokio-uring enable configuration
-                    // on building runtime.
-                    let _ = config.max_blocking_threads;
-                    Arbiter::new()
-                };
-
-                #[cfg(not(all(target_os = "linux", feature = "io-uring")))]
                 let arbiter = {
                     Arbiter::with_tokio_rt(move || {
                         tokio::runtime::Builder::new_current_thread()

--- a/justfile
+++ b/justfile
@@ -30,14 +30,7 @@ msrv := ```
     | sed -E 's/^1\.([0-9]{2})$/1\.\1\.0/'
 ```
 msrv_rustup := "+" + msrv
-non_linux_all_features_list := ```
-    cargo metadata --format-version=1 \
-    | jq '.packages[] | select(.source == null) | .features | keys' \
-    | jq -r --slurp \
-        --arg exclusions "tokio-uring,io-uring" \
-        'add | unique | . - ($exclusions | split(",")) | join(",")'
-```
-all_crate_features := if os() == "linux" { "--all-features" } else { "--features='" + non_linux_all_features_list + "'" }
+all_crate_features := "--all-features"
 
 # Run Clippy over workspace.
 clippy:
@@ -60,7 +53,6 @@ test:
 test:
     cargo {{ toolchain }} test --lib --tests --package=actix-macros
     cargo {{ toolchain }} nextest run --no-tests=warn --workspace --exclude=actix-macros --no-default-features
-    cargo {{ toolchain }} nextest run --no-tests=warn --workspace --exclude=actix-macros {{ non_linux_all_features_list }}
     cargo {{ toolchain }} nextest run --no-tests=warn --workspace --exclude=actix-macros {{ all_crate_features }}
 
 # Test workspace using MSRV.


### PR DESCRIPTION
## Summary

- Remove the experimental `io-uring` features and `tokio-uring` dependencies from `actix-rt` and `actix-server`.
- Use the regular Tokio system, arbiter, and worker paths unconditionally.
- Remove feature-specific tests and CI exclusions, and regenerate `Cargo.lock`.

## Validation

- `cargo check --workspace --all-features`
- `just clippy` (passes with existing warnings)
- `cargo test --locked --package actix-rt --package actix-server --all-features`
- `cargo +nightly fmt -- --check`
- `cargo metadata --locked --format-version=1 --no-deps`
- `git diff --check`

The no-default-features workspace test run passed. The full `just test` run was stopped by the unrelated environment-specific `actix-tls::test_connect::test_local_addr` failure (`AddrNotAvailable`). `just check` also reports existing formatting issues in `deny.toml` and `actix-tls/Cargo.toml`.
