### PR TITLE
feat: use Tokio LocalRuntime for server workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -543,7 +543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -993,7 +993,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1628,7 +1628,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2060,7 +2060,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2673,7 +2673,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.9.0
+
 - Use Tokio `LocalRuntime`s for workers instead of `LocalSet`s.
 
 ## 2.8.0

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use Tokio `LocalRuntime`s for workers instead of `LocalSet`s.
+
 ## 2.8.0
 
 - Remove experimental `io-uring` support.

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -29,7 +29,7 @@ futures-core = { version = "0.3.17", default-features = false, features = ["allo
 futures-util = { version = "0.3.17", default-features = false, features = ["alloc"] }
 mio = { version = "1", features = ["os-poll", "net"] }
 socket2 = "0.6"
-tokio = { version = "1.44.2", features = ["sync"] }
+tokio = { version = "1.51", features = ["rt", "sync"] }
 tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 [dev-dependencies]
@@ -40,7 +40,7 @@ bytes = "1"
 futures-util = { version = "0.3.17", default-features = false, features = ["sink", "async-await-macro"] }
 pretty_env_logger = "0.5"
 static_assertions = "1"
-tokio = { version = "1.44.2", features = ["io-util", "rt-multi-thread", "macros", "fs", "time"] }
+tokio = { version = "1.51", features = ["io-util", "rt-multi-thread", "macros", "fs", "time"] }
 tokio-util = "0.7"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-server"
-version = "2.8.0"
+version = "2.9.0"
 authors = [
   "Nikolay Kim <fafhrd91@gmail.com>",
   "Rob Ede <robjtede@icloud.com>",

--- a/actix-server/README.md
+++ b/actix-server/README.md
@@ -5,11 +5,11 @@
 <!-- prettier-ignore-start -->
 
 [![crates.io](https://img.shields.io/crates/v/actix-server?label=latest)](https://crates.io/crates/actix-server)
-[![Documentation](https://docs.rs/actix-server/badge.svg?version=2.8.0)](https://docs.rs/actix-server/2.8.0)
+[![Documentation](https://docs.rs/actix-server/badge.svg?version=2.9.0)](https://docs.rs/actix-server/2.9.0)
 [![Version](https://img.shields.io/badge/rustc-1.88+-ab6000.svg)](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/actix-server.svg)
 <br />
-[![Dependency Status](https://deps.rs/crate/actix-server/2.8.0/status.svg)](https://deps.rs/crate/actix-server/2.8.0)
+[![Dependency Status](https://deps.rs/crate/actix-server/2.9.0/status.svg)](https://deps.rs/crate/actix-server/2.9.0)
 ![Download](https://img.shields.io/crates/d/actix-server.svg)
 [![Chat on Discord](https://img.shields.io/discord/771444961383153695?label=chat&logo=discord)](https://discord.gg/NWpN5mmg3x)
 

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -18,9 +18,12 @@ use actix_rt::{
     Arbiter, ArbiterHandle, System,
 };
 use futures_core::{future::LocalBoxFuture, ready};
-use tokio::sync::{
-    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-    oneshot,
+use tokio::{
+    runtime::{Builder, LocalOptions},
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        oneshot,
+    },
 };
 use tracing::{error, info, trace};
 
@@ -305,17 +308,20 @@ impl ServerWorker {
             }
 
             // no actix system
-            (None, Some(rt_handle)) => {
+            (None, Some(_)) => {
                 std::thread::Builder::new()
                     .name(format!("actix-server worker {idx}"))
                     .spawn(move || {
                         let (worker_stopped_tx, worker_stopped_rx) = oneshot::channel();
 
-                        // local set for running service init futures and worker services
-                        let ls = tokio::task::LocalSet::new();
+                        let rt = Builder::new_current_thread()
+                            .enable_all()
+                            .max_blocking_threads(config.max_blocking_threads)
+                            .build_local(LocalOptions::default())
+                            .unwrap();
 
-                        // init services using existing Tokio runtime (so probably on main thread)
-                        let services = rt_handle.block_on(ls.run_until(async {
+                        // init services using the worker's local runtime
+                        let services = rt.block_on(async {
                             let mut services = Vec::new();
 
                             for (idx, factory) in factories.iter().enumerate() {
@@ -332,7 +338,7 @@ impl ServerWorker {
                             }
 
                             Ok(services)
-                        }));
+                        });
 
                         let services = match services {
                             Ok(services) => {
@@ -368,13 +374,7 @@ impl ServerWorker {
                             worker_stopped_rx.await.unwrap();
                         };
 
-                        let rt = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .max_blocking_threads(config.max_blocking_threads)
-                            .build()
-                            .unwrap();
-
-                        rt.block_on(ls.run_until(worker_fut));
+                        rt.block_on(worker_fut);
                     })
                     .expect("cannot spawn server worker thread");
             }

--- a/actix-server/tests/server.rs
+++ b/actix-server/tests/server.rs
@@ -12,7 +12,7 @@ use std::{
 
 use actix_rt::{net::TcpStream, time::sleep};
 use actix_server::{Server, TestServer};
-use actix_service::fn_service;
+use actix_service::{fn_factory, fn_service};
 
 fn unused_addr() -> net::SocketAddr {
     TestServer::unused_addr()
@@ -97,7 +97,10 @@ fn plain_tokio_runtime() {
                 .workers(1)
                 .disable_signals()
                 .bind("test", addr, move || {
-                    fn_service(|_| async { Ok::<_, ()>(()) })
+                    fn_factory(|| async {
+                        sleep(Duration::from_millis(10)).await;
+                        Ok::<_, ()>(fn_service(|_| async { Ok::<_, ()>(()) }))
+                    })
                 })?
                 .run();
 


### PR DESCRIPTION
## Summary

- use Tokio `LocalRuntime` for worker initialization and execution in a plain Tokio runtime
- remove cross-thread `Handle::block_on` and `LocalSet` from that worker path
- raise the Tokio minimum to 1.51 and cover timer-backed factory initialization

Refs #597
