### PR TITLE
actix-rt: Add fallible Arbiter spawn APIs (try_new & try_with_tokio_rt)

### DIFF
--- a/actix-rt/CHANGES.md
+++ b/actix-rt/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `Arbiter::try_new` and `Arbiter::try_with_tokio_rt` for fallible Arbiter initialization without panicking the creator thread.
+
 ## 2.12.0
 
 - Add `SystemRunner::stop_future` and `SystemRunner::into_parts` for awaiting system stop inside `block_on`.

--- a/actix-rt/src/arbiter.rs
+++ b/actix-rt/src/arbiter.rs
@@ -2,6 +2,7 @@ use std::{
     cell::RefCell,
     fmt,
     future::Future,
+    io,
     pin::Pin,
     sync::atomic::{AtomicUsize, Ordering},
     task::{Context, Poll},
@@ -94,12 +95,22 @@ impl Arbiter {
     /// Spawn a new Arbiter thread and start its event loop.
     ///
     /// # Panics
-    /// Panics if a [System] is not registered on the current thread.
+    /// Panics if a [System] is not registered on the current thread, or if creating the Arbiter's
+    /// thread or Tokio runtime fails.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Arbiter {
-        Self::with_tokio_rt(|| {
-            crate::runtime::default_tokio_runtime().expect("Cannot create new Arbiter's Runtime.")
-        })
+        Self::try_new().expect("Cannot create new Arbiter's Runtime.")
+    }
+
+    /// Try to spawn a new Arbiter thread and start its event loop with the default Tokio runtime.
+    ///
+    /// # Panics
+    /// Panics if a [System] is not registered on the current thread.
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if creating the underlying OS thread or Tokio runtime fails.
+    pub fn try_new() -> io::Result<Arbiter> {
+        Self::try_with_tokio_rt(crate::runtime::default_tokio_runtime)
     }
 
     /// Spawn a new Arbiter using the [Tokio Runtime](tokio-runtime) returned from a closure.
@@ -108,11 +119,38 @@ impl Arbiter {
     /// `tokio::runtime::Runtime`, `Arc<tokio::runtime::Runtime>`, or
     /// `&'static tokio::runtime::Runtime`.
     ///
+    /// # Panics
+    /// Panics if a [System] is not registered on the current thread, or if creating the Arbiter's
+    /// thread or Tokio runtime fails.
+    ///
     /// [tokio-runtime]: tokio::runtime::Runtime
     /// [`Runtime`]: crate::Runtime
     pub fn with_tokio_rt<F, R>(runtime_factory: F) -> Arbiter
     where
         F: FnOnce() -> R + Send + 'static,
+        R: Into<crate::runtime::Runtime> + Send + 'static,
+    {
+        Self::try_with_tokio_rt(|| Ok::<_, io::Error>(runtime_factory()))
+            .unwrap_or_else(|err| panic!("Cannot create new Arbiter: {err:?}"))
+    }
+
+    /// Try to spawn a new Arbiter using the [Tokio Runtime](tokio-runtime) returned from a closure.
+    ///
+    /// The closure may return any `Result` whose success value can be converted into [`Runtime`],
+    /// such as `tokio::runtime::Runtime`, `Arc<tokio::runtime::Runtime>`, or
+    /// `&'static tokio::runtime::Runtime`.
+    ///
+    /// # Panics
+    /// Panics if a [System] is not registered on the current thread.
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if creating the underlying OS thread or Tokio runtime fails.
+    ///
+    /// [tokio-runtime]: tokio::runtime::Runtime
+    /// [`Runtime`]: crate::Runtime
+    pub fn try_with_tokio_rt<F, R>(runtime_factory: F) -> io::Result<Arbiter>
+    where
+        F: FnOnce() -> io::Result<R> + Send + 'static,
         R: Into<crate::runtime::Runtime> + Send + 'static,
     {
         let sys = System::current();
@@ -122,41 +160,57 @@ impl Arbiter {
         let name = format!("actix-rt|system:{system_id}|arbiter:{arb_id}");
         let (tx, rx) = mpsc::unbounded_channel();
 
-        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<io::Result<()>>();
 
-        let thread_handle = thread::Builder::new()
-            .name(name.clone())
-            .spawn({
-                let tx = tx.clone();
-                move || {
-                    let rt = runtime_factory().into();
-                    let hnd = ArbiterHandle::new(tx);
+        let thread_handle = thread::Builder::new().name(name.clone()).spawn({
+            let tx = tx.clone();
+            move || {
+                let rt = match runtime_factory() {
+                    Ok(rt) => rt.into(),
+                    Err(err) => {
+                        let _ = ready_tx.send(Err(err));
+                        return;
+                    }
+                };
 
-                    System::set_current(sys);
+                let hnd = ArbiterHandle::new(tx);
 
-                    HANDLE.with(|cell| *cell.borrow_mut() = Some(hnd.clone()));
+                System::set_current(sys);
 
-                    // register arbiter
-                    let _ = System::current()
-                        .tx()
-                        .send(SystemCommand::RegisterArbiter(arb_id, hnd));
+                HANDLE.with(|cell| *cell.borrow_mut() = Some(hnd.clone()));
 
-                    ready_tx.send(()).unwrap();
+                // register arbiter
+                let _ = System::current()
+                    .tx()
+                    .send(SystemCommand::RegisterArbiter(arb_id, hnd));
 
-                    // run arbiter event processing loop
-                    rt.block_on(ArbiterRunner { rx });
-
-                    // deregister arbiter
-                    let _ = System::current()
-                        .tx()
-                        .send(SystemCommand::DeregisterArbiter(arb_id));
+                if ready_tx.send(Ok(())).is_err() {
+                    return;
                 }
-            })
-            .unwrap_or_else(|err| panic!("Cannot spawn Arbiter's thread: {name:?}: {err:?}"));
 
-        ready_rx.recv().unwrap();
+                // run arbiter event processing loop
+                rt.block_on(ArbiterRunner { rx });
 
-        Arbiter { tx, thread_handle }
+                // deregister arbiter
+                let _ = System::current()
+                    .tx()
+                    .send(SystemCommand::DeregisterArbiter(arb_id));
+            }
+        })?;
+
+        match ready_rx.recv() {
+            Ok(Ok(())) => Ok(Arbiter { tx, thread_handle }),
+            Ok(Err(err)) => {
+                let _ = thread_handle.join();
+                Err(err)
+            }
+            Err(_) => {
+                let _ = thread_handle.join();
+                Err(io::Error::other(format!(
+                    "Arbiter thread {name} failed to initialize"
+                )))
+            }
+        }
     }
 
     /// Sets up an Arbiter runner in a new System using the environment's local set.

--- a/actix-rt/tests/tests.rs
+++ b/actix-rt/tests/tests.rs
@@ -455,3 +455,30 @@ fn spawn_local() {
         h(actix_rt::spawn(async { 1 }));
     })
 }
+
+#[test]
+fn arbiter_spawn_failure_does_not_panic_creator() {
+    let _ = System::new();
+
+    // 1. Happy path: try_new succeeds when System is active
+    let arb = Arbiter::try_new().expect("Arbiter::try_new should succeed");
+    arb.stop();
+    arb.join().unwrap();
+
+    // 2. Simulated runtime factory failure (e.g. OS error 24 EMFILE / FD exhaustion)
+    let res = Arbiter::try_with_tokio_rt(|| {
+        Err::<tokio::runtime::Runtime, _>(std::io::Error::from_raw_os_error(24))
+    });
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().raw_os_error(), Some(24));
+
+    // 3. Simulated panic in background thread during runtime initialization
+    let (panic_tx, panic_rx) = channel();
+    let res = Arbiter::try_with_tokio_rt(move || -> std::io::Result<tokio::runtime::Runtime> {
+        panic_tx.send(()).unwrap();
+        panic!("simulated tokio runtime initialization panic");
+    });
+
+    assert_eq!(panic_rx.recv(), Ok(()));
+    assert!(res.is_err());
+}


### PR DESCRIPTION
Fixes #703.

### Description
Adds `Arbiter::try_new` and `Arbiter::try_with_tokio_rt` returning `io::Result<Arbiter>` to prevent creator threads from crashing on `ready_rx.recv().unwrap()` when Tokio runtime or thread creation fails.

Implements the safe API and `sync::mpsc::channel`-based test approach proposed by [@dontloseyourheadsu](https://github.com/actix/actix-net/issues/703#issuecomment-3698438897) and [@JohnTitor](https://github.com/actix/actix-net/issues/703#issuecomment-3866045262).