### PR TITLE
fix: keep workers alive until graceful stop

### DIFF
--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -665,7 +665,12 @@ impl Future for ServerWorker {
                             .call((guard, msg.io))
                             .into_inner();
                     }
-                    None => return Poll::Ready(()),
+                    None => {
+                        // The accept channel can close before the server's stop command reaches
+                        // this worker. `stop_rx` was polled above and will wake this worker when
+                        // the command arrives.
+                        return Poll::Pending;
+                    }
                 };
             },
         }

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -507,10 +507,18 @@ impl ServerWorker {
 
 #[derive(Default)]
 enum WorkerState {
-    Available,
+    /// At least one worker service is not ready. New connections are not dispatched.
     #[default]
     Unavailable,
+
+    /// All worker services are ready and queued connections are dispatched to them.
+    Available,
+
+    /// A failed worker service is being recreated. New connections are not dispatched.
     Restarting(Restart),
+
+    /// The worker is gracefully shutting down. Queued connections are dropped while active
+    /// connections are given time to finish.
     Shutdown(Shutdown),
 }
 


### PR DESCRIPTION
## Motivation

`graceful_shutdown_closes_idle_http1_connection_after_in_flight_request` was flaky in CI. During graceful shutdown, an in-flight HTTP/1 request must remain alive until the server's stop command is processed. Returning the worker future as complete can drop the active dispatcher and terminate the request with EOF.

## Investigation

The failure was reproduced in a constrained Linux `amd64` Docker container (`--cpus=1 --memory=2g`) with 32 concurrent workers and 1,000 attempts.

Temporary tracing showed this sequence:

1. The accept/connection channel closed while one connection was still active.
2. The worker completed before its separate stop command was received.
3. Dropping the worker stopped its arbiter and dropped the in-flight handler future.
4. The client observed `UnexpectedEof`.

The paired baseline run produced 44 failures (4.4%) using the current regression-test timing. The earlier original 500 ms test-window baseline was 68/1,000 (6.8%).

## Fix

When `conn_rx` closes, return `Poll::Pending` instead of `Poll::Ready(())`. `stop_rx` is polled before `conn_rx`, so its waker is already registered. The server's stop command wakes the worker, which then enters the existing graceful-shutdown path.

This keeps the fix at the existing poll seam and does not add another worker state.

## Validation

- `cargo fmt -- --check`
- `cargo test -p actix-server`
  - 11 unit tests
  - 7 integration tests passed, 1 ignored
  - 2 testing-server tests
  - 4 doctests
- Constrained Linux stress test: 1,000 attempts, 32 concurrent workers, 1 CPU, 2 GB RAM
  - baseline: 44 failures (4.4%)
  - fixed: 0 failures (0.0%)

The temporary diagnostic logging was removed after the failure sequence and ownership bug were confirmed.
