### PR TITLE
fix(actix-server): clean up acceptor and worker threads on drop

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Clean up acceptor and worker threads when `Server` is dropped or cancelled, immediately releasing bound listening sockets and ports. Reported by Istvan Zolyomi ([@izolyomi](https://github.com/izolyomi)).
+
 ## 2.9.1
 
 - Fix race condition where accept thread shutdown cause cause workers to be dropped prematurely.

--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -386,3 +386,21 @@ impl Stream for ServerEventMultiplexer {
         this.cmd_rx.poll_recv(cx)
     }
 }
+
+impl Drop for ServerInner {
+    fn drop(&mut self) {
+        if !self.stopping {
+            self.stopping = true;
+
+            self.waker_queue.wake(WakerInterest::Stop);
+
+            for worker in &self.worker_handles {
+                let _completion_rx = worker.stop(false);
+            }
+
+            if let Some(handle) = self.accept_handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+}

--- a/actix-server/tests/server.rs
+++ b/actix-server/tests/server.rs
@@ -626,3 +626,33 @@ fn no_runtime_on_init() {
     })
     .unwrap();
 }
+
+#[actix_rt::test]
+async fn server_drop_release_port() {
+    let addr = unused_addr();
+    let noop = || fn_service(|_| async { Ok::<_, ()>(()) });
+
+    let srv = Server::build()
+        .workers(1)
+        .disable_signals()
+        .bind("test", addr, noop)
+        .unwrap()
+        .run();
+
+    let task = actix_rt::spawn(srv);
+    sleep(Duration::from_millis(100)).await;
+
+    task.abort();
+    let _ = task.await;
+
+    let new_srv = Server::build()
+        .workers(1)
+        .disable_signals()
+        .bind("test2", addr, noop);
+
+    assert!(
+        new_srv.is_ok(),
+        "failed to re-bind port after server was dropped: {:?}",
+        new_srv.err()
+    );
+}


### PR DESCRIPTION
Dropping or cancelling a `Server` future detached the background acceptor OS thread without stopping it, leaving listening TCP sockets open and causing subsequent binds to fail with `EADDRINUSE`.

Huge thanks to **Istvan Zolyomi** (@izolyomi) for isolating and reporting this bug in https://github.com/actix/actix-web/issues/3765, where dropped/cancelled servers left ports permanently bound in resilient reinitialization workflows.

### Summary of Changes
- Implements `Drop for ServerInner` to wake the acceptor's `mio::Poll` loop, stop workers, and join the thread so socket file descriptors are closed and the port is freed immediately.
- Adds an integration test ensuring cancelled server tasks release ports immediately.
- Adds changelog entry in `actix-server/CHANGES.md` (crediting @izolyomi).

Fixes https://github.com/actix/actix-web/issues/3765
Refs https://github.com/actix/actix-web/discussions/3025
Reported-by: @izolyomi