### PR TITLE
fix(actix-server): clean up cancelled servers during shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "socket2",
  "static_assertions",
  "tokio",
+ "tokio-test",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -2436,6 +2437,7 @@ dependencies = [
  "futures-sink",
  "libc",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 

--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Close listeners and request forced worker shutdown when a running server is dropped, including during graceful shutdown.
+
 ## 2.9.1
 
 - Fix race condition where accept thread shutdown could cause workers to be dropped prematurely.

--- a/actix-server/Cargo.toml
+++ b/actix-server/Cargo.toml
@@ -41,7 +41,8 @@ futures-util = { version = "0.3.17", default-features = false, features = ["sink
 pretty_env_logger = "0.5"
 static_assertions = "1"
 tokio = { version = "1.51", features = ["io-util", "rt-multi-thread", "macros", "fs", "time"] }
-tokio-util = "0.7"
+tokio-test = "0.4"
+tokio-util = { version = "0.7", features = ["time"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [lints]

--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -66,12 +66,22 @@ pub(crate) enum ServerCommand {
 /// server has fully shut down.
 ///
 /// # Shutdown Signals
+///
 /// On UNIX systems, `SIGTERM` will start a graceful shutdown and `SIGQUIT` or `SIGINT` will start a
 /// forced shutdown. On Windows, a Ctrl-C signal will start a forced shutdown.
 ///
 /// A graceful shutdown will wait for all workers to stop first.
 ///
+/// # Drop Behavior
+///
+/// Dropping a running server closes its listeners and requests **forced** worker shutdown,
+/// including when graceful shutdown is still in progress.
+///
+/// Drop waits for the acceptor thread to exit, but does not wait for worker threads to exit. Keep
+/// polling the server until it completes to finish a graceful shutdown.
+///
 /// # Examples
+///
 /// The following is a TCP echo server. Test using `telnet 127.0.0.1 8080`.
 ///
 /// ```no_run
@@ -384,5 +394,24 @@ impl Stream for ServerEventMultiplexer {
         }
 
         this.cmd_rx.poll_recv(cx)
+    }
+}
+
+impl Drop for ServerInner {
+    fn drop(&mut self) {
+        if let Some(handle) = self.accept_handle.take() {
+            // Shutdown may have started without completing. Do not wake an acceptor
+            // that has already received Stop and may have dropped its poll instance.
+            if !self.stopping {
+                self.waker_queue.wake(WakerInterest::Stop);
+            }
+
+            for worker in &self.worker_handles {
+                drop(worker.stop(false));
+            }
+
+            // The acceptor owns the listeners. Wait for it to release them.
+            let _ = handle.join();
+        }
     }
 }

--- a/actix-server/tests/server.rs
+++ b/actix-server/tests/server.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::let_underscore_future, missing_docs)]
 
 use std::{
-    future::{ready, Ready},
-    net,
+    future::{pending, ready, Ready},
+    net::{self, SocketAddr},
     sync::{
         atomic::{AtomicUsize, Ordering},
         mpsc, Arc,
@@ -15,6 +15,10 @@ use std::{
 use actix_rt::{net::TcpStream, time::sleep};
 use actix_server::{Server, TestServer};
 use actix_service::{fn_factory, fn_service, Service};
+use futures_util::{task::noop_waker, FutureExt as _};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio_test::{assert_pending, assert_ready, assert_ready_ok};
+use tokio_util::future::FutureExt as _;
 
 fn unused_addr() -> net::SocketAddr {
     TestServer::unused_addr()
@@ -625,4 +629,115 @@ fn no_runtime_on_init() {
         srv.await
     })
     .unwrap();
+}
+
+#[tokio::test]
+async fn dropped_server_releases_listener() {
+    let addr = unused_addr();
+    let mut server = Server::build()
+        .workers(1)
+        .disable_signals()
+        .bind("test", addr, || fn_service(|_| async { Ok::<_, ()>(()) }))
+        .unwrap()
+        .run();
+
+    // Start the acceptor before dropping the server.
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert_pending!(server.poll_unpin(&mut cx));
+    drop(server);
+
+    let _listener =
+        net::TcpListener::bind(addr).expect("listener should close before drop returns");
+}
+
+fn basic_ready_server() -> (Server, SocketAddr) {
+    let addr = unused_addr();
+    let server = Server::build()
+        .workers(1)
+        .disable_signals()
+        .shutdown_timeout(60)
+        .bind("test", addr, || {
+            fn_service(|mut stream: TcpStream| async move {
+                stream.write_all(b"ready").await.unwrap();
+                pending::<()>().await;
+                drop(stream);
+                Ok::<_, ()>(())
+            })
+        })
+        .unwrap()
+        .run();
+
+    (server, addr)
+}
+
+#[tokio::test]
+async fn dropped_server_interrupts_graceful_shutdown() {
+    let (mut server, addr) = basic_ready_server();
+
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert_pending!(server.poll_unpin(&mut cx));
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    let mut ready = [0; 5];
+    client
+        .read_exact(&mut ready)
+        .timeout(Duration::from_secs(5))
+        .await
+        .expect("service should start")
+        .unwrap();
+    assert_eq!(&ready, b"ready");
+
+    let completion = server.handle().stop(true);
+    // Process the stop request, leaving shutdown pending on the active connection.
+    assert_pending!(server.poll_unpin(&mut cx));
+    drop(server);
+    drop(completion);
+
+    let mut buf = [0; 1];
+    let bytes = client
+        .read(&mut buf)
+        .timeout(Duration::from_secs(5))
+        .await
+        .expect("cancellation should close the connection before the graceful shutdown timeout")
+        .unwrap();
+    assert_eq!(bytes, 0);
+
+    let _listener =
+        net::TcpListener::bind(addr).expect("listener should close before drop returns");
+}
+
+#[tokio::test]
+async fn non_graceful_shutdown_completes_before_server_drop() {
+    let (mut server, addr) = basic_ready_server();
+
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert_pending!(server.poll_unpin(&mut cx));
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    let mut ready = [0; 5];
+    client
+        .read_exact(&mut ready)
+        .timeout(Duration::from_secs(5))
+        .await
+        .expect("service should start")
+        .unwrap();
+    assert_eq!(&ready, b"ready");
+
+    let mut completion = Box::pin(server.handle().stop(false));
+    assert_ready_ok!(server.poll_unpin(&mut cx));
+    assert_ready!(completion.poll_unpin(&mut cx));
+    drop(server);
+
+    let mut buf = [0; 1];
+    let bytes = client
+        .read(&mut buf)
+        .timeout(Duration::from_secs(5))
+        .await
+        .expect("forced shutdown should close the active connection")
+        .unwrap();
+    assert_eq!(bytes, 0);
+
+    let _listener =
+        net::TcpListener::bind(addr).expect("listener should close before drop returns");
 }


### PR DESCRIPTION
## Overview

Dropping or cancelling a running `Server` previously detached its acceptor thread and left listening ports bound. Close the listeners before drop returns and request forced worker shutdown, including when cancellation interrupts an unfinished graceful shutdown.

Use the outstanding acceptor join handle to detect incomplete cleanup. If shutdown has already started, force-stop workers and join the acceptor without waking its potentially closed poll instance again. Normal explicit non-graceful shutdown remains unchanged. Document that drop waits for the acceptor but does not wait for worker threads to exit.

Supersedes and obsoletes #953. That proposal covers cancellation while running, but its `!stopping` guard skips cleanup when cancellation interrupts graceful shutdown. Thanks to @Sruhvx-jpg for the original proposal and @izolyomi for reporting the issue.

Fixes https://github.com/actix/actix-web/issues/3765

## PR Type

Bug Fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with rustfmt (repository nightly recipe).

## Validation

- `cargo test --offline -p actix-server`: 28 passed, 1 ignored on macOS.
- `just all_crate_features='' clippy`: workspace and all targets, default features.
- `cargo +nightly fmt -- --check`.
- The listener-release regression failed with `AddrInUse` before cleanup was added. The graceful-shutdown cancellation regression failed with the original proposal's guard and passes with this implementation.
- Tests cover dropping a running server, cancelling graceful shutdown with an active connection, and explicit non-graceful shutdown. Both shutdown tests verify connection closure and port reuse.
