### PR TITLE
feat(server): add TestServer::unused_listener helper

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `TestServer::unused_listener()` to return a TCP listener and its local address while keeping the port reserved.
+
 ## 2.9.4
 
 - Cap the default worker count at 512 and reject explicit counts above 512 in `ServerBuilder::workers()` before starting workers.

--- a/actix-server/src/test_server.rs
+++ b/actix-server/src/test_server.rs
@@ -83,7 +83,19 @@ impl TestServer {
     }
 
     /// Get first available unused local address.
+    ///
+    /// The listener is dropped before this method returns, so the port is no longer reserved.
+    /// Use [`Self::unused_listener()`] to keep the port reserved.
     pub fn unused_addr() -> net::SocketAddr {
+        Self::unused_listener().1
+    }
+
+    /// Bind a TCP listener to an OS-assigned port on the IPv4 loopback address.
+    ///
+    /// Returns the nonblocking listener and its local address. The caller owns the listener, which
+    /// keeps the port reserved until it is dropped. Unlike [`Self::unused_addr()`], this method
+    /// leaves the listener open so it can be passed to [`ServerBuilder::listen()`].
+    pub fn unused_listener() -> (net::TcpListener, net::SocketAddr) {
         use socket2::{Domain, Protocol, Socket, Type};
 
         let addr: net::SocketAddr = "127.0.0.1:0".parse().unwrap();
@@ -95,7 +107,9 @@ impl TestServer {
         socket.bind(&addr.into()).unwrap();
         socket.listen(1024).unwrap();
 
-        net::TcpListener::from(socket).local_addr().unwrap()
+        let listener = net::TcpListener::from(socket);
+        let addr = listener.local_addr().unwrap();
+        (listener, addr)
     }
 }
 

--- a/actix-server/tests/server.rs
+++ b/actix-server/tests/server.rs
@@ -150,15 +150,15 @@ fn test_start() {
     use bytes::Bytes;
     use futures_util::sink::SinkExt;
 
-    let (lst, addr) = TestServer::unused_listener();
-    socket2::SockRef::from(&lst).listen(100).unwrap();
+    let addr = TestServer::unused_addr();
     let (tx, rx) = mpsc::channel();
 
     let h = thread::spawn(move || {
         actix_rt::System::new().block_on(async {
             let srv = Server::build()
+                .backlog(100)
                 .disable_signals()
-                .listen("test", lst, move || {
+                .bind("test", addr, move || {
                     fn_service(|io: TcpStream| async move {
                         let mut f = Framed::new(io, BytesCodec);
                         f.send(Bytes::from_static(b"test")).await.unwrap();
@@ -220,8 +220,7 @@ async fn test_max_concurrent_connections() {
 
     use tokio::io::AsyncWriteExt;
 
-    let (lst, addr) = TestServer::unused_listener();
-    socket2::SockRef::from(&lst).listen(12).unwrap();
+    let addr = TestServer::unused_addr();
     let (tx, rx) = mpsc::channel();
 
     let counter = Arc::new(AtomicUsize::new(0));
@@ -232,11 +231,13 @@ async fn test_max_concurrent_connections() {
     let h = thread::spawn(move || {
         actix_rt::System::new().block_on(async {
             let srv = Server::build()
+                // Set a relative higher backlog.
+                .backlog(12)
                 // max connection for a worker is 3.
                 .max_concurrent_connections(max_conn)
                 .workers(1)
                 .disable_signals()
-                .listen("test", lst, move || {
+                .bind("test", addr, move || {
                     let counter = counter.clone();
                     fn_service(move |_io: TcpStream| {
                         let counter = counter.clone();
@@ -306,8 +307,7 @@ async fn test_max_concurrent_connections_releases_capacity() {
 
 #[tokio::test]
 async fn graceful_shutdown_drops_queued_connections() {
-    let (lst, addr) = TestServer::unused_listener();
-    socket2::SockRef::from(&lst).listen(1).unwrap();
+    let addr = TestServer::unused_addr();
     let (tx, rx) = mpsc::channel();
     let ready = Arc::new(AtomicUsize::new(0));
     let calls = Arc::new(AtomicUsize::new(0));
@@ -324,11 +324,12 @@ async fn graceful_shutdown_drops_queued_connections() {
 
             rt.block_on(async {
                 let srv = Server::build()
+                    .backlog(1)
                     .max_concurrent_connections(1)
                     .workers(1)
                     .disable_signals()
                     .shutdown_timeout(5)
-                    .listen("test", lst, move || {
+                    .bind("test", addr, move || {
                         let ready = ready.clone();
                         let calls = calls.clone();
 
@@ -401,10 +402,8 @@ async fn test_service_restart() {
         }
     }
 
-    let (lst1, addr1) = TestServer::unused_listener();
-    let (lst2, addr2) = TestServer::unused_listener();
-    socket2::SockRef::from(&lst1).listen(1).unwrap();
-    socket2::SockRef::from(&lst2).listen(1).unwrap();
+    let addr1 = TestServer::unused_addr();
+    let addr2 = TestServer::unused_addr();
     let (tx, rx) = mpsc::channel();
     let num = Arc::new(AtomicUsize::new(0));
     let num2 = Arc::new(AtomicUsize::new(0));
@@ -416,15 +415,16 @@ async fn test_service_restart() {
         let num = num.clone();
         actix_rt::System::new().block_on(async {
             let srv = Server::build()
+                .backlog(1)
                 .disable_signals()
-                .listen("addr1", lst1, move || {
+                .bind("addr1", addr1, move || {
                     let num = num.clone();
                     fn_factory(move || {
                         let num = num.clone();
                         async move { Ok::<_, ()>(TestService(num)) }
                     })
                 })?
-                .listen("addr2", lst2, move || {
+                .bind("addr2", addr2, move || {
                     let num2 = num2.clone();
                     fn_factory(move || {
                         let num2 = num2.clone();

--- a/actix-server/tests/server.rs
+++ b/actix-server/tests/server.rs
@@ -20,10 +20,6 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio_test::{assert_pending, assert_ready, assert_ready_ok};
 use tokio_util::future::FutureExt as _;
 
-fn unused_addr() -> net::SocketAddr {
-    TestServer::unused_addr()
-}
-
 struct PendingService {
     ready: Arc<AtomicUsize>,
     calls: Arc<AtomicUsize>,
@@ -47,7 +43,7 @@ impl Service<TcpStream> for PendingService {
 
 #[test]
 fn test_bind() {
-    let addr = unused_addr();
+    let addr = TestServer::unused_addr();
     let (tx, rx) = mpsc::channel();
 
     let h = thread::spawn(move || {
@@ -78,9 +74,8 @@ fn test_bind() {
 
 #[test]
 fn test_listen() {
-    let addr = unused_addr();
+    let (lst, addr) = TestServer::unused_listener();
     let (tx, rx) = mpsc::channel();
-    let lst = net::TcpListener::bind(addr).unwrap();
 
     let h = thread::spawn(move || {
         actix_rt::System::new().block_on(async {
@@ -110,7 +105,7 @@ fn test_listen() {
 
 #[test]
 fn plain_tokio_runtime() {
-    let addr = unused_addr();
+    let (lst, addr) = TestServer::unused_listener();
     let (tx, rx) = mpsc::channel();
 
     let h = thread::spawn(move || {
@@ -123,7 +118,7 @@ fn plain_tokio_runtime() {
             let srv = Server::build()
                 .workers(1)
                 .disable_signals()
-                .bind("test", addr, move || {
+                .listen("test", lst, move || {
                     fn_factory(|| async {
                         sleep(Duration::from_millis(10)).await;
                         Ok::<_, ()>(fn_service(|_| async { Ok::<_, ()>(()) }))
@@ -155,15 +150,15 @@ fn test_start() {
     use bytes::Bytes;
     use futures_util::sink::SinkExt;
 
-    let addr = unused_addr();
+    let (lst, addr) = TestServer::unused_listener();
+    socket2::SockRef::from(&lst).listen(100).unwrap();
     let (tx, rx) = mpsc::channel();
 
     let h = thread::spawn(move || {
         actix_rt::System::new().block_on(async {
             let srv = Server::build()
-                .backlog(100)
                 .disable_signals()
-                .bind("test", addr, move || {
+                .listen("test", lst, move || {
                     fn_service(|io: TcpStream| async move {
                         let mut f = Framed::new(io, BytesCodec);
                         f.send(Bytes::from_static(b"test")).await.unwrap();
@@ -225,7 +220,8 @@ async fn test_max_concurrent_connections() {
 
     use tokio::io::AsyncWriteExt;
 
-    let addr = unused_addr();
+    let (lst, addr) = TestServer::unused_listener();
+    socket2::SockRef::from(&lst).listen(12).unwrap();
     let (tx, rx) = mpsc::channel();
 
     let counter = Arc::new(AtomicUsize::new(0));
@@ -236,13 +232,11 @@ async fn test_max_concurrent_connections() {
     let h = thread::spawn(move || {
         actix_rt::System::new().block_on(async {
             let srv = Server::build()
-                // Set a relative higher backlog.
-                .backlog(12)
                 // max connection for a worker is 3.
                 .max_concurrent_connections(max_conn)
                 .workers(1)
                 .disable_signals()
-                .bind("test", addr, move || {
+                .listen("test", lst, move || {
                     let counter = counter.clone();
                     fn_service(move |_io: TcpStream| {
                         let counter = counter.clone();
@@ -312,7 +306,8 @@ async fn test_max_concurrent_connections_releases_capacity() {
 
 #[tokio::test]
 async fn graceful_shutdown_drops_queued_connections() {
-    let addr = unused_addr();
+    let (lst, addr) = TestServer::unused_listener();
+    socket2::SockRef::from(&lst).listen(1).unwrap();
     let (tx, rx) = mpsc::channel();
     let ready = Arc::new(AtomicUsize::new(0));
     let calls = Arc::new(AtomicUsize::new(0));
@@ -329,12 +324,11 @@ async fn graceful_shutdown_drops_queued_connections() {
 
             rt.block_on(async {
                 let srv = Server::build()
-                    .backlog(1)
                     .max_concurrent_connections(1)
                     .workers(1)
                     .disable_signals()
                     .shutdown_timeout(5)
-                    .bind("test", addr, move || {
+                    .listen("test", lst, move || {
                         let ready = ready.clone();
                         let calls = calls.clone();
 
@@ -407,8 +401,10 @@ async fn test_service_restart() {
         }
     }
 
-    let addr1 = unused_addr();
-    let addr2 = unused_addr();
+    let (lst1, addr1) = TestServer::unused_listener();
+    let (lst2, addr2) = TestServer::unused_listener();
+    socket2::SockRef::from(&lst1).listen(1).unwrap();
+    socket2::SockRef::from(&lst2).listen(1).unwrap();
     let (tx, rx) = mpsc::channel();
     let num = Arc::new(AtomicUsize::new(0));
     let num2 = Arc::new(AtomicUsize::new(0));
@@ -420,16 +416,15 @@ async fn test_service_restart() {
         let num = num.clone();
         actix_rt::System::new().block_on(async {
             let srv = Server::build()
-                .backlog(1)
                 .disable_signals()
-                .bind("addr1", addr1, move || {
+                .listen("addr1", lst1, move || {
                     let num = num.clone();
                     fn_factory(move || {
                         let num = num.clone();
                         async move { Ok::<_, ()>(TestService(num)) }
                     })
                 })?
-                .bind("addr2", addr2, move || {
+                .listen("addr2", lst2, move || {
                     let num2 = num2.clone();
                     fn_factory(move || {
                         let num2 = num2.clone();
@@ -530,7 +525,7 @@ async fn worker_restart() {
         }
     }
 
-    let addr = unused_addr();
+    let (lst, addr) = TestServer::unused_listener();
     let (tx, rx) = mpsc::channel();
 
     let counter = Arc::new(AtomicUsize::new(1));
@@ -539,7 +534,7 @@ async fn worker_restart() {
         actix_rt::System::new().block_on(async {
             let srv = Server::build()
                 .disable_signals()
-                .bind("addr", addr, move || TestServiceFactory(counter.clone()))?
+                .listen("addr", lst, move || TestServiceFactory(counter.clone()))?
                 .workers(2)
                 .run();
 
@@ -614,13 +609,13 @@ async fn worker_restart() {
 fn no_runtime_on_init() {
     use std::{thread::sleep, time::Duration};
 
-    let addr = unused_addr();
+    let (lst, _addr) = TestServer::unused_listener();
     let counter = Arc::new(AtomicUsize::new(0));
 
     let mut srv = Server::build()
         .workers(2)
         .disable_signals()
-        .bind("test", addr, {
+        .listen("test", lst, {
             let counter = counter.clone();
             move || {
                 counter.fetch_add(1, Ordering::SeqCst);

--- a/actix-server/tests/server.rs
+++ b/actix-server/tests/server.rs
@@ -20,6 +20,10 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio_test::{assert_pending, assert_ready, assert_ready_ok};
 use tokio_util::future::FutureExt as _;
 
+fn unused_addr() -> net::SocketAddr {
+    TestServer::unused_addr()
+}
+
 struct PendingService {
     ready: Arc<AtomicUsize>,
     calls: Arc<AtomicUsize>,
@@ -43,7 +47,7 @@ impl Service<TcpStream> for PendingService {
 
 #[test]
 fn test_bind() {
-    let addr = TestServer::unused_addr();
+    let addr = unused_addr();
     let (tx, rx) = mpsc::channel();
 
     let h = thread::spawn(move || {
@@ -150,7 +154,7 @@ fn test_start() {
     use bytes::Bytes;
     use futures_util::sink::SinkExt;
 
-    let addr = TestServer::unused_addr();
+    let addr = unused_addr();
     let (tx, rx) = mpsc::channel();
 
     let h = thread::spawn(move || {
@@ -220,7 +224,7 @@ async fn test_max_concurrent_connections() {
 
     use tokio::io::AsyncWriteExt;
 
-    let addr = TestServer::unused_addr();
+    let addr = unused_addr();
     let (tx, rx) = mpsc::channel();
 
     let counter = Arc::new(AtomicUsize::new(0));
@@ -307,7 +311,7 @@ async fn test_max_concurrent_connections_releases_capacity() {
 
 #[tokio::test]
 async fn graceful_shutdown_drops_queued_connections() {
-    let addr = TestServer::unused_addr();
+    let addr = unused_addr();
     let (tx, rx) = mpsc::channel();
     let ready = Arc::new(AtomicUsize::new(0));
     let calls = Arc::new(AtomicUsize::new(0));
@@ -402,8 +406,8 @@ async fn test_service_restart() {
         }
     }
 
-    let addr1 = TestServer::unused_addr();
-    let addr2 = TestServer::unused_addr();
+    let addr1 = unused_addr();
+    let addr2 = unused_addr();
     let (tx, rx) = mpsc::channel();
     let num = Arc::new(AtomicUsize::new(0));
     let num2 = Arc::new(AtomicUsize::new(0));

--- a/actix-server/tests/testing_server.rs
+++ b/actix-server/tests/testing_server.rs
@@ -18,6 +18,28 @@ macro_rules! await_timeout_ms {
 }
 
 #[tokio::test]
+async fn unused_listener_accepts_connections() {
+    let (listener, addr) = TestServer::unused_listener();
+    assert_eq!(listener.local_addr().unwrap(), addr);
+    assert!(addr.ip().is_loopback());
+    assert_ne!(addr.port(), 0);
+
+    let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+    let client = tokio::time::timeout(std::time::Duration::from_secs(1), TcpStream::connect(addr))
+        .await
+        .unwrap()
+        .unwrap();
+    let (accepted, peer_addr) =
+        tokio::time::timeout(std::time::Duration::from_secs(1), listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+
+    assert_eq!(accepted.local_addr().unwrap(), addr);
+    assert_eq!(peer_addr, client.local_addr().unwrap());
+}
+
+#[tokio::test]
 async fn testing_server_echo() {
     let srv = TestServer::start(|| {
         fn_service(move |mut stream: TcpStream| async move {

--- a/actix-server/tests/testing_server.rs
+++ b/actix-server/tests/testing_server.rs
@@ -73,11 +73,11 @@ async fn testing_server_echo() {
 
 #[tokio::test]
 async fn new_with_builder() {
-    let alt_addr = TestServer::unused_addr();
+    let (alt_listener, alt_addr) = TestServer::unused_listener();
 
     let srv = TestServer::start_with_builder(
         Server::build()
-            .bind("alt", alt_addr, || {
+            .listen("alt", alt_listener, || {
                 fn_service(|_| async { Ok::<_, ()>(()) })
             })
             .unwrap(),


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

Add `TestServer::unused_listener()` to return a TCP listener and its OS-assigned local address. Callers own the listener and retain the port reservation until they drop it or transfer ownership to a server.

Reuse the existing socket setup, including address reuse, nonblocking mode, and the listen backlog. Implement `unused_addr()` through the new helper while preserving its signature and behavior: it drops the listener before returning the address. Document this ownership difference and add a focused test that connects to the returned address and accepts the connection.

Use the helper in server integration tests to retain port reservations through server setup. Keep tests with custom backlogs on their existing `ServerBuilder::bind` setup, and keep `test_bind` for bind coverage.

## Validation

- `just check` passed, including the repository's nightly rustfmt check and workspace Clippy.
- `cargo nextest run --no-tests=warn -p actix-server --no-default-features` passed all 25 enabled tests; the existing ignored worker-restart test was skipped.




