### PR TITLE
fix(server): cap default workers and validate explicit counts

### DIFF
--- a/actix-server/CHANGES.md
+++ b/actix-server/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Cap the default worker count at 512 and reject explicit counts above 512 in `ServerBuilder::workers()` before starting workers.
+
 ## 2.9.3
 
 - Fix workers failing to accept new connections after reaching the configured connection limit, even after existing connections finish.

--- a/actix-server/src/availability.rs
+++ b/actix-server/src/availability.rs
@@ -1,8 +1,10 @@
 use crate::worker::WorkerHandleAccept;
 
+pub(crate) const MAX_WORKERS: usize = 512;
+
 /// Array of u128 with every bit as marker for a worker handle's availability.
 #[derive(Debug, Default)]
-pub(crate) struct Availability([u128; 4]);
+pub(crate) struct Availability([u128; MAX_WORKERS / u128::BITS as usize]);
 
 impl Availability {
     /// Check if any worker handle is available

--- a/actix-server/src/builder.rs
+++ b/actix-server/src/builder.rs
@@ -8,6 +8,7 @@ use tokio::sync::{
 };
 
 use crate::{
+    availability::MAX_WORKERS,
     server::ServerCommand,
     service::{InternalServiceFactory, ServerServiceFactory, StreamNewService},
     socket::{create_mio_tcp_listener, MioListener, MioTcpListener, StdTcpListener, ToSocketAddrs},
@@ -59,11 +60,17 @@ impl Default for ServerBuilder {
 impl ServerBuilder {
     /// Create new Server builder instance
     pub fn new() -> ServerBuilder {
+        Self::with_default_workers(
+            std::thread::available_parallelism().map_or(2, NonZeroUsize::get),
+        )
+    }
+
+    fn with_default_workers(threads: usize) -> ServerBuilder {
         let (cmd_tx, cmd_rx) = unbounded_channel();
         let (graceful_shutdown_tx, _) = watch::channel(());
 
         ServerBuilder {
-            threads: std::thread::available_parallelism().map_or(2, NonZeroUsize::get),
+            threads: threads.min(MAX_WORKERS),
             token: 0,
             factories: Vec::new(),
             sockets: Vec::new(),
@@ -92,16 +99,17 @@ impl ServerBuilder {
     /// See [`bind()`](Self::bind()) for more details on how worker count affects the number of
     /// server factory instantiations.
     ///
-    /// The default worker count is the determined by [`std::thread::available_parallelism()`]. See
-    /// its documentation to determine what behavior you should expect when server is run.
+    /// The default worker count is determined by [`std::thread::available_parallelism()`], capped
+    /// at 512. See its documentation for how the available parallelism is determined.
     ///
-    /// `num` must be greater than 0.
+    /// `num` must be in the range 1–512.
     ///
     /// # Panics
     ///
-    /// Panics if `num` is 0.
+    /// Panics if `num` is 0 or greater than 512.
     pub fn workers(mut self, num: usize) -> Self {
         assert_ne!(num, 0, "workers must be greater than 0");
+        assert!(num <= MAX_WORKERS, "workers must not exceed {MAX_WORKERS}");
         self.threads = num;
         self
     }
@@ -317,6 +325,10 @@ impl ServerBuilder {
     }
 
     /// Starts processing incoming connections and return server controller.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no sockets are bound.
     pub fn run(self) -> Server {
         if self.sockets.is_empty() {
             panic!("Server should have at least one bound socket");
@@ -423,5 +435,53 @@ pub(super) fn bind_addr<S: ToSocketAddrs>(
         Err(err)
     } else {
         Err(io::Error::other("Can not bind to address."))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServerBuilder;
+
+    #[test]
+    #[should_panic(expected = "workers must not exceed 512")]
+    fn rejects_worker_count_above_limit() {
+        ServerBuilder::new().workers(513);
+    }
+
+    #[test]
+    #[should_panic(expected = "workers must be greater than 0")]
+    fn rejects_zero_workers() {
+        ServerBuilder::new().workers(0);
+    }
+
+    #[test]
+    fn accepts_worker_count_boundaries() {
+        ServerBuilder::new().workers(1);
+        ServerBuilder::new().workers(512);
+    }
+
+    #[test]
+    fn default_worker_count_is_capped() {
+        for detected in [513, 768, 1920, usize::MAX] {
+            assert_eq!(ServerBuilder::with_default_workers(detected).threads, 512);
+        }
+    }
+
+    #[test]
+    fn oversized_default_worker_count_can_be_overridden() {
+        assert_eq!(
+            ServerBuilder::with_default_workers(768).workers(1).threads,
+            1
+        );
+    }
+
+    #[test]
+    fn supported_default_worker_count_is_preserved() {
+        for detected in [1, 2, 64, 512] {
+            assert_eq!(
+                ServerBuilder::with_default_workers(detected).threads,
+                detected
+            );
+        }
     }
 }


### PR DESCRIPTION
Worker counts above 512 currently reach availability initialization only after the workers have been started, where they panic. This can happen with an explicit `.workers(513)` or when `available_parallelism()` supplies an oversized default.

Cap the detected default at 512 so systems with more available CPUs select a supported worker count automatically. Reject explicit counts outside 1–512 in `.workers()`, before startup. Document the behavior and share the limit with the availability bitset size.

Refs #957.

Validation:
- Explicit-count rejection and default-clamping regressions were observed failing before their respective fixes.
- Tests cover explicit boundary values, simulated defaults above 512, preservation of supported defaults, and overriding the capped default.
- `just test`: 117 tests passed without default features; 138 passed with all features (one skipped in each run). Run with socket access outside the sandbox.
- `just clippy` passed.
- `cargo +nightly fmt -- --check` passed.
