### PR TITLE
refactor(server): name timeout and capacity constants

### DIFF
--- a/actix-server/src/accept.rs
+++ b/actix-server/src/accept.rs
@@ -12,7 +12,10 @@ use crate::{
     ServerBuilder, ServerHandle,
 };
 
-const TIMEOUT_DURATION_ON_ERROR: Duration = Duration::from_millis(510);
+const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(500);
+// Allow a 10 ms margin after the listener's retry deadline.
+const ACCEPT_ERROR_POLL_TIMEOUT: Duration =
+    ACCEPT_ERROR_BACKOFF.saturating_add(Duration::from_millis(10));
 
 struct ServerSocketInfo {
     token: usize,
@@ -409,8 +412,8 @@ impl Accept {
                     // sleep after error. write the timeout to socket info as later
                     // the poll would need it mark which socket and when it's
                     // listener should be registered
-                    info.timeout = Some(Instant::now() + Duration::from_millis(500));
-                    self.set_timeout(TIMEOUT_DURATION_ON_ERROR);
+                    info.timeout = Some(Instant::now() + ACCEPT_ERROR_BACKOFF);
+                    self.set_timeout(ACCEPT_ERROR_POLL_TIMEOUT);
 
                     return;
                 }

--- a/actix-server/src/server.rs
+++ b/actix-server/src/server.rs
@@ -24,6 +24,8 @@ use crate::{
     ServerHandle,
 };
 
+const SYSTEM_STOP_DELAY: Duration = Duration::from_millis(300);
+
 #[derive(Debug)]
 pub(crate) enum ServerCommand {
     /// Worker failed to accept connection, indicating a probable panic.
@@ -295,7 +297,7 @@ impl ServerInner {
                 }
 
                 if self.system_stop || force_system_stop {
-                    sleep(Duration::from_millis(300)).await;
+                    sleep(SYSTEM_STOP_DELAY).await;
                     System::try_current().as_ref().map(System::stop);
                 }
             }

--- a/actix-server/src/waker_queue.rs
+++ b/actix-server/src/waker_queue.rs
@@ -8,6 +8,8 @@ use mio::{Registry, Token as MioToken, Waker};
 
 use crate::worker::WorkerHandleAccept;
 
+const INITIAL_QUEUE_CAPACITY: usize = 16;
+
 /// Waker token for `mio::Poll` instance.
 pub(crate) const WAKER_TOKEN: MioToken = MioToken(usize::MAX);
 
@@ -36,7 +38,7 @@ impl WakerQueue {
     /// event's token for it to properly handle `WakerInterest`.
     pub(crate) fn new(registry: &Registry) -> std::io::Result<Self> {
         let waker = Waker::new(registry, WAKER_TOKEN)?;
-        let queue = Mutex::new(VecDeque::with_capacity(16));
+        let queue = Mutex::new(VecDeque::with_capacity(INITIAL_QUEUE_CAPACITY));
 
         Ok(Self(Arc::new((waker, queue))))
     }
@@ -62,7 +64,7 @@ impl WakerQueue {
 
     /// Reset the waker queue so it does not grow infinitely.
     pub(crate) fn reset(queue: &mut VecDeque<WakerInterest>) {
-        *queue = VecDeque::<WakerInterest>::with_capacity(16);
+        *queue = VecDeque::<WakerInterest>::with_capacity(INITIAL_QUEUE_CAPACITY);
     }
 }
 

--- a/actix-server/src/worker.rs
+++ b/actix-server/src/worker.rs
@@ -33,6 +33,10 @@ use crate::{
     waker_queue::{WakerInterest, WakerQueue},
 };
 
+// Based on the default maximum blocking thread count of a Tokio runtime.
+const DEFAULT_BLOCKING_THREAD_BUDGET: usize = 512;
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
 /// Stop worker message. Returns `true` on successful graceful shutdown
 /// and `false` if some connections still alive when shutdown execute.
 pub(crate) struct Stop {
@@ -278,8 +282,7 @@ impl Default for ServerWorkerConfig {
     fn default() -> Self {
         let parallelism = std::thread::available_parallelism().map_or(2, NonZeroUsize::get);
 
-        // 512 is the default max blocking thread count of a Tokio runtime.
-        let max_blocking_threads = std::cmp::max(512 / parallelism, 1);
+        let max_blocking_threads = std::cmp::max(DEFAULT_BLOCKING_THREAD_BUDGET / parallelism, 1);
 
         Self {
             shutdown_timeout: Duration::from_secs(30),
@@ -592,7 +595,7 @@ impl Future for ServerWorker {
                 this.shutdown(false);
 
                 this.state = WorkerState::Shutdown(Shutdown {
-                    timer: Box::pin(sleep(Duration::from_secs(1))),
+                    timer: Box::pin(sleep(SHUTDOWN_POLL_INTERVAL)),
                     start_from: Instant::now(),
                     tx,
                 });
@@ -652,7 +655,7 @@ impl Future for ServerWorker {
                     drop((conn, guard));
                 }
 
-                // wait for 1 second
+                // Wait until the next shutdown check.
                 ready!(shutdown.timer.as_mut().poll(cx));
 
                 if this.counter.total() == 0 {
@@ -670,8 +673,8 @@ impl Future for ServerWorker {
 
                     Poll::Ready(())
                 } else {
-                    // reset timer and wait for 1 second
-                    let time = Instant::now() + Duration::from_secs(1);
+                    // Schedule the next shutdown check.
+                    let time = Instant::now() + SHUTDOWN_POLL_INTERVAL;
                     shutdown.timer.as_mut().reset(time);
                     shutdown.timer.as_mut().poll(cx)
                 }


### PR DESCRIPTION
Name the server's accept-error backoff, shutdown polling interval, system-stop delay, initial waker queue capacity, and default blocking-thread budget. Shared constants keep queue construction/reset and shutdown timer initialization/reset consistent. Express the accept-error poll timeout as the existing 500 ms backoff plus its 10 ms margin.

All numeric values and runtime behavior are preserved. The constants remain private to their modules.

Refs #957.

Validation: `just test` passed (117 tests without default features, 138 with all features; one skipped in each run), `just clippy` passed, and `cargo +nightly fmt -- --check` passed. The test recipe ran with socket access outside the sandbox.
