### PR TITLE
fix(codec): support separate read and write halves

### DIFF
--- a/actix-codec/CHANGES.md
+++ b/actix-codec/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Relaxed `Framed::new` bounds to support separate read and write halves with decoder-only and encoder-only codecs.
+
 ## 0.5.3
 
 - Added `LinesCodec::new_with_max_length` to enforce a maximum line length and mitigate potential unbounded-buffer DoS when handling untrusted input.

--- a/actix-codec/Cargo.toml
+++ b/actix-codec/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { version = "0.1.30", default-features = false, features = ["log"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+tokio = { version = "1.44.2", features = ["io-util"] }
 tokio-test = "0.4.2"
 
 [[bench]]

--- a/actix-codec/src/framed.rs
+++ b/actix-codec/src/framed.rs
@@ -43,14 +43,13 @@ pin_project! {
     }
 }
 
-impl<T, U> Framed<T, U>
-where
-    T: AsyncRead + AsyncWrite,
-    U: Decoder,
-{
-    /// This function returns a *single* object that is both `Stream` and `Sink`; grouping this into
-    /// a single object is often useful for layering things like gzip or TLS, which require both
-    /// read and write access to the underlying object.
+impl<T, U> Framed<T, U> {
+    /// Creates a framed transport from an I/O object and a codec.
+    ///
+    /// The transport implements `Stream` when the I/O object implements `AsyncRead` and the codec
+    /// implements `Decoder`. It implements `Sink<I>` when the I/O object implements `AsyncWrite`
+    /// and the codec implements `Encoder<I>`. Read and write halves can therefore use separate
+    /// codecs.
     pub fn new(io: T, codec: U) -> Framed<T, U> {
         Framed {
             io,

--- a/actix-codec/tests/test_framed_halves.rs
+++ b/actix-codec/tests/test_framed_halves.rs
@@ -1,0 +1,59 @@
+#![allow(missing_docs)]
+
+use std::{io, pin::Pin};
+
+use actix_codec::{Decoder, Encoder, Framed, LinesCodec};
+use bytes::BytesMut;
+use futures_core::Stream;
+use futures_sink::Sink;
+use tokio_test::{assert_ready, task};
+
+struct ReadCodec(LinesCodec);
+
+impl Decoder for ReadCodec {
+    type Item = String;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> io::Result<Option<String>> {
+        self.0.decode(src)
+    }
+}
+
+struct WriteCodec;
+
+impl Encoder<&[u8]> for WriteCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, item: &[u8], dst: &mut BytesMut) -> io::Result<()> {
+        dst.extend_from_slice(item);
+        Ok(())
+    }
+}
+
+#[test]
+fn read_half_with_decoder_only() {
+    let io = tokio_test::io::Builder::new().read(b"hello\n").build();
+    let (read, _write) = tokio::io::split(io);
+    let mut framed = Framed::new(read, ReadCodec(LinesCodec::default()));
+
+    task::spawn(()).enter(|cx, _| {
+        let item = assert_ready!(Pin::new(&mut framed).poll_next(cx));
+        assert_eq!(item.unwrap().unwrap(), "hello");
+        assert!(assert_ready!(Pin::new(&mut framed).poll_next(cx)).is_none());
+    });
+}
+
+#[test]
+fn write_half_with_encoder_only() {
+    let io = tokio_test::io::Builder::new().write(b"hello\n").build();
+    let (_read, write) = tokio::io::split(io);
+    let mut framed = Framed::new(write, WriteCodec);
+
+    task::spawn(()).enter(|cx, _| {
+        let mut framed = Pin::new(&mut framed);
+        assert_ready!(framed.as_mut().poll_ready(cx)).unwrap();
+        framed.as_mut().start_send(&b"hello\n"[..]).unwrap();
+        assert_ready!(framed.as_mut().poll_flush(cx)).unwrap();
+        assert_ready!(framed.poll_close(cx)).unwrap();
+    });
+}


### PR DESCRIPTION
Remove the unnecessary bounds from `Framed::new` so read and write halves can use separate decoder-only and encoder-only codecs. Existing callers keep the same API and behavior; the `Stream` and `Sink` implementations retain their bounds.

Closes #453.

## PR Type

Bug Fix

## PR Checklist

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with rustfmt (nightly, as specified by the justfile).

## Validation

- Confirmed both regression tests fail on the original constructor bounds.
- `cargo test -p actix-codec` — 12 tests passed.
- `just clippy` — workspace, all targets and features passed.
- `cargo +nightly fmt -p actix-codec -- --check` — passed.

Cargo reports an existing unrelated manifest warning in `actix-tls`.

