### PR TITLE
docs(tls): add Rustls and OpenSSL credential hot-reload examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "actix-server",
  "actix-service",
  "actix-utils",
+ "arc-swap",
  "bytes",
  "futures-core",
  "futures-util",
@@ -177,6 +178,15 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "asn1-rs"

--- a/actix-tls/Cargo.toml
+++ b/actix-tls/Cargo.toml
@@ -118,6 +118,7 @@ rustls-webpki-0103 = { package = "rustls-webpki", version = "0.103.10", optional
 actix-codec = "0.5"
 actix-rt = "2.2"
 actix-server = "2"
+arc-swap = "1.9"
 bytes = "1"
 futures-util = { version = "0.3.17", default-features = false, features = ["sink"] }
 hickory-resolver = "0.26.1"
@@ -125,11 +126,20 @@ itertools = "0.14"
 pretty_env_logger = "0.5"
 rcgen = "0.14"
 rustls-pemfile = "2"
+tokio = { version = "1.51", features = ["macros", "rt"] }
 tokio-rustls-026 = { package = "tokio-rustls", version = "0.26" }
 
 [[example]]
 name = "accept-rustls"
 required-features = ["accept", "rustls-0_23"]
+
+[[example]]
+name = "hot-reload-rustls"
+required-features = ["accept", "rustls-0_23"]
+
+[[example]]
+name = "hot-reload-openssl"
+required-features = ["accept", "openssl"]
 
 [lints.rust]
 rust_2018_idioms = "deny"

--- a/actix-tls/README.md
+++ b/actix-tls/README.md
@@ -19,3 +19,4 @@
 
 - [Library Documentation](https://docs.rs/actix-tls)
 - [Examples](/actix-tls/examples)
+- [TLS credential hot reload](examples/hot-reload.md)

--- a/actix-tls/examples/hot-reload-openssl.rs
+++ b/actix-tls/examples/hot-reload-openssl.rs
@@ -1,0 +1,136 @@
+//! Reload TLS credentials without restarting the server.
+//!
+//! See `examples/hot-reload.md` for run and verification instructions.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use actix_server::Server;
+use actix_service::ServiceFactoryExt as _;
+use actix_tls::accept::openssl::{Acceptor, TlsStream};
+use arc_swap::ArcSwap;
+use futures_util::future::ok;
+use tls_openssl::ssl::{SniError, SslAcceptor, SslMethod};
+use tokio::net::TcpStream;
+
+#[tokio::main(flavor = "local")]
+async fn main() -> io::Result<()> {
+    let (cert, key) =
+        parse_args().inspect_err(|_| eprintln!("usage: hot-reload-openssl CERT KEY"))?;
+    let shared = Arc::new(ReloadingAcceptor::new(&cert, &key)?);
+    let acceptor = Acceptor::new(shared.acceptor()?);
+
+    let server = Server::build()
+        .bind("tls-reload", ("127.0.0.1", 8443), move || {
+            acceptor
+                .clone()
+                .map_err(|err| eprintln!("TLS error: {err:?}"))
+                .and_then(|_stream: TlsStream<TcpStream>| ok(()))
+        })?
+        .workers(2)
+        .run();
+
+    let reload = spawn_reload(move || shared.reload(&cert, &key));
+
+    eprintln!("Listening on 127.0.0.1:8443; checking credentials every 2 seconds");
+    let result = server.await;
+    reload.abort();
+    result
+}
+
+/// Returns the parsed certificate and key paths from the command line.
+fn parse_args() -> io::Result<(PathBuf, PathBuf)> {
+    let mut args = std::env::args_os().skip(1);
+    let cert = args
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid certificate path"))?;
+    let key = args
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid key path"))?;
+    Ok((cert.into(), key.into()))
+}
+
+/// All workers share the current context. Each handshake loads a snapshot.
+struct ReloadingAcceptor {
+    current: ArcSwap<Credentials>,
+}
+
+struct Credentials {
+    acceptor: SslAcceptor,
+    certificate_pem: Vec<u8>,
+}
+
+impl ReloadingAcceptor {
+    fn new(cert: &Path, key: &Path) -> io::Result<Self> {
+        Ok(Self {
+            current: ArcSwap::from_pointee(load_acceptor(cert, key)?),
+        })
+    }
+
+    fn acceptor(self: &Arc<Self>) -> io::Result<SslAcceptor> {
+        let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;
+        let shared = Arc::clone(self);
+        // Use the current context for every handshake, regardless of the requested server name.
+        builder.set_servername_callback(move |ssl, _alert| {
+            let current = shared.current.load();
+            ssl.set_ssl_context(current.acceptor.context())
+                .map_err(|_| SniError::ALERT_FATAL)
+        });
+        Ok(builder.build())
+    }
+
+    fn reload(&self, cert: &Path, key: &Path) -> io::Result<bool> {
+        // Read and validate both files before replacing the shared context.
+        let replacement = load_acceptor(cert, key)?;
+        let current = self.current.load();
+        if current.certificate_pem == replacement.certificate_pem {
+            return Ok(false);
+        }
+        self.current.store(Arc::new(replacement));
+        Ok(true)
+    }
+}
+
+fn load_acceptor(cert: &Path, key: &Path) -> io::Result<Credentials> {
+    let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;
+    let pem = fs::read(cert)?;
+    let mut chain = tls_openssl::x509::X509::stack_from_pem(&pem)?.into_iter();
+    let leaf = chain
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no certificate found"))?;
+    builder.set_certificate(&leaf)?;
+    for cert in chain {
+        builder.add_extra_chain_cert(cert)?;
+    }
+    // Parse the key without an interactive password prompt.
+    let key = tls_openssl::pkey::PKey::private_key_from_pem(&fs::read(key)?)?;
+    builder.set_private_key(&key)?;
+    builder.check_private_key()?;
+    Ok(Credentials {
+        acceptor: builder.build(),
+        certificate_pem: pem,
+    })
+}
+
+/// Runs file access and key parsing outside the async runtime and TLS workers.
+fn spawn_reload(
+    reload: impl Fn() -> io::Result<bool> + Send + Sync + 'static,
+) -> tokio::task::JoinHandle<()> {
+    let reload = Arc::new(reload);
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            let reload = Arc::clone(&reload);
+            match tokio::task::spawn_blocking(move || reload()).await {
+                Ok(Ok(true)) => eprintln!("TLS credentials reloaded"),
+                Ok(Ok(false)) => {}
+                Ok(Err(err)) => eprintln!("TLS reload failed; keeping current credentials: {err}"),
+                Err(err) => eprintln!("TLS reload task failed: {err}"),
+            }
+        }
+    })
+}

--- a/actix-tls/examples/hot-reload-rustls.rs
+++ b/actix-tls/examples/hot-reload-rustls.rs
@@ -1,0 +1,127 @@
+//! Reload TLS credentials without restarting the server.
+//!
+//! See `examples/hot-reload.md` for run and verification instructions.
+
+use std::{
+    fs::File,
+    io::{self, BufReader},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use actix_server::Server;
+use actix_service::ServiceFactoryExt as _;
+use actix_tls::accept::rustls_0_23::{Acceptor, TlsStream};
+use arc_swap::ArcSwap;
+use futures_util::future::ok;
+use tokio::net::TcpStream;
+use tokio_rustls_026::rustls::{
+    self,
+    crypto::CryptoProvider,
+    server::{ClientHello, ResolvesServerCert},
+    sign::CertifiedKey,
+    ServerConfig,
+};
+
+#[tokio::main(flavor = "local")]
+async fn main() -> io::Result<()> {
+    let (cert, key) =
+        parse_args().inspect_err(|_| eprintln!("usage: hot-reload-rustls CERT KEY"))?;
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let resolver = Arc::new(ReloadingResolver::new(&cert, &key, &provider)?);
+    let config = ServerConfig::builder_with_provider(Arc::clone(&provider))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_no_client_auth()
+        .with_cert_resolver(resolver.clone());
+    let acceptor = Acceptor::new(config);
+
+    let server = Server::build()
+        .bind("tls-reload", ("127.0.0.1", 8443), move || {
+            acceptor
+                .clone()
+                .map_err(|err| eprintln!("TLS error: {err:?}"))
+                .and_then(|_stream: TlsStream<TcpStream>| ok(()))
+        })?
+        .workers(2)
+        .run();
+
+    let reload = spawn_reload(move || resolver.reload(&cert, &key, &provider));
+
+    eprintln!("Listening on 127.0.0.1:8443; checking credentials every 2 seconds");
+    let result = server.await;
+    reload.abort();
+    result
+}
+
+fn parse_args() -> io::Result<(PathBuf, PathBuf)> {
+    let mut args = std::env::args_os().skip(1);
+    let cert = args
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid certificate path"))?;
+    let key = args
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid key path"))?;
+    Ok((cert.into(), key.into()))
+}
+
+/// All workers use the same resolver. Each handshake loads an owned snapshot of the key.
+#[derive(Debug)]
+struct ReloadingResolver(ArcSwap<CertifiedKey>);
+
+impl ResolvesServerCert for ReloadingResolver {
+    fn resolve(&self, _hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        Some(self.0.load_full())
+    }
+}
+
+impl ReloadingResolver {
+    fn new(cert: &Path, key: &Path, provider: &CryptoProvider) -> io::Result<Self> {
+        Ok(Self(ArcSwap::from_pointee(load_key(cert, key, provider)?)))
+    }
+
+    fn reload(&self, cert: &Path, key: &Path, provider: &CryptoProvider) -> io::Result<bool> {
+        // Read and validate both files before publishing the replacement. A failed reload leaves
+        // the current credentials in place, including when only one file has been replaced.
+        let replacement = load_key(cert, key, provider)?;
+        let current = self.0.load();
+        if current.cert == replacement.cert {
+            return Ok(false);
+        }
+        self.0.store(Arc::new(replacement));
+        Ok(true)
+    }
+}
+
+fn load_key(cert: &Path, key: &Path, provider: &CryptoProvider) -> io::Result<CertifiedKey> {
+    let certs = rustls_pemfile::certs(&mut BufReader::new(File::open(cert)?))
+        .collect::<io::Result<Vec<_>>>()?;
+    let key = rustls_pemfile::private_key(&mut BufReader::new(File::open(key)?))?
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no private key found"))?;
+    let certified = CertifiedKey::from_der(certs, key, provider)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    certified
+        .keys_match()
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    Ok(certified)
+}
+
+/// Runs file access and key parsing outside the async runtime and TLS workers.
+fn spawn_reload(
+    reload: impl Fn() -> io::Result<bool> + Send + Sync + 'static,
+) -> tokio::task::JoinHandle<()> {
+    let reload = Arc::new(reload);
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            let reload = Arc::clone(&reload);
+            match tokio::task::spawn_blocking(move || reload()).await {
+                Ok(Ok(true)) => eprintln!("TLS credentials reloaded"),
+                Ok(Ok(false)) => {}
+                Ok(Err(err)) => eprintln!("TLS reload failed; keeping current credentials: {err}"),
+                Err(err) => eprintln!("TLS reload task failed: {err}"),
+            }
+        }
+    })
+}

--- a/actix-tls/examples/hot-reload.md
+++ b/actix-tls/examples/hot-reload.md
@@ -1,0 +1,56 @@
+# TLS Credential Hot Reload
+
+The `hot-reload-rustls.rs` and `hot-reload-openssl.rs` examples are each self-contained. Each file separates server setup, credential loading, and the polling task into functions.
+
+The `hot-reload-rustls` example uses Rustls 0.23 to replace a certificate and private key without restarting the server or rebinding its listener. All workers share a certificate resolver backed by `arc-swap`. Each handshake loads an owned snapshot of the current credentials. Every two seconds, a blocking task reads the PEM files and validates that the key matches the leaf certificate. It installs the pair only after validation succeeds. Missing, incomplete, or mismatched files leave the current credentials in use. Invalid credentials at startup stop the server.
+
+Install [mkcert](https://github.com/FiloSottile/mkcert#installation), then run these commands from the workspace root to generate test credentials in a separate directory:
+
+```sh
+mkdir -p /tmp/actix-tls-reload
+mkcert -key-file /tmp/actix-tls-reload/key.pem -cert-file /tmp/actix-tls-reload/cert.pem localhost 127.0.0.1 ::1
+cargo run -p actix-tls --example hot-reload-rustls --features rustls-0_23 -- /tmp/actix-tls-reload/cert.pem /tmp/actix-tls-reload/key.pem
+```
+
+To inspect the generated certificate, use [`inspect-cert-chain`](https://github.com/robjtede/inspect-cert-chain):
+
+```sh
+inspect-cert-chain --file /tmp/actix-tls-reload/cert.pem
+```
+
+In another terminal, inspect the certificate served by a fresh TLS connection:
+
+```sh
+inspect-cert-chain --host localhost --port 8443
+```
+
+Generate a replacement pair, then move both files into place:
+
+```sh
+mkcert -key-file /tmp/actix-tls-reload/key.next.pem -cert-file /tmp/actix-tls-reload/cert.next.pem localhost 127.0.0.1 ::1
+mv /tmp/actix-tls-reload/key.next.pem /tmp/actix-tls-reload/key.pem
+mv /tmp/actix-tls-reload/cert.next.pem /tmp/actix-tls-reload/cert.pem
+```
+
+After the server logs `TLS credentials reloaded`, repeat the inspection command. The serial and fingerprint change while the server process and listener stay in place. To test failure handling, replace `cert.pem` with an empty file. After a reload error, a fresh connection still receives the last valid certificate.
+
+This is a TLS-only example: it closes each connection after the handshake and does not send an HTTP response. In an application, established TLS connections continue with their existing state. Only new full handshakes use the new certificate; resumed sessions can omit certificate exchange. This example does not revoke sessions, validate certificate expiry or trust, or select certificates by SNI. Use a certificate chain with the leaf certificate first.
+
+The same resolver can be passed to the Rustls config builder's `with_cert_resolver` for Actix Web's `HttpServer::bind_rustls_0_23`. Keep the resolver shared with the reload task and configure the HTTP server as usual. No Actix TLS library change is required.
+
+## OpenSSL
+
+The `hot-reload-openssl` example provides the same behavior with OpenSSL. Run it with the test credentials generated above, after stopping the Rustls example:
+
+```sh
+cargo run -p actix-tls --example hot-reload-openssl --features openssl -- \
+  /tmp/actix-tls-reload/cert.pem /tmp/actix-tls-reload/key.pem
+```
+
+Use the same replacement and inspection commands above. All workers share the current OpenSSL context. Every two seconds, a blocking task loads the certificate chain and private key into a new context and checks that they match. It replaces the shared context only when the validated certificate PEM contents change. Invalid files leave the current context in use; invalid startup credentials stop the server.
+
+The [OpenSSL server name callback](https://docs.rs/openssl/latest/openssl/ssl/struct.SslAcceptorBuilder.html#method.set_servername_callback) selects the current context for each handshake. It does not select by hostname and also works for clients that omit SNI. The callback uses `arc-swap` to load a snapshot of the context. File access and key parsing finish before the reload task atomically publishes the replacement. As with the Rustls example, this server closes connections after the handshake and does not serve HTTP. The same limits on session resumption, certificate validation, and revocation apply. Private keys must be unencrypted PEM files.
+
+For Actix Web, pass the callback-equipped builder to `HttpServer::bind_openssl` and keep the reload task running. No Actix TLS library change is required.
+
+Related requests: [actix-net#13](https://github.com/actix/actix-net/issues/13) and [actix-web#754](https://github.com/actix/actix-web/issues/754).


### PR DESCRIPTION
## PR Type

Documentation / examples

## PR Checklist

- [ ] Tests for the changes have been added / updated. Manual live checks are listed below; no automated tests were added.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages. Examples only; no library API change.
- [ ] Format code with the latest stable rustfmt. Formatted and checked with nightly rustfmt, as used by the justfile.

## Overview

Add Rustls 0.23 and OpenSSL examples that reload certificate and private-key PEM files without restarting the server or rebinding its listener. Each example checks the files every two seconds, validates the pair, and publishes the replacement through a shared `ArcSwap`. Invalid replacements keep the last valid credentials; invalid startup credentials stop the server.

Add Cargo example feature requirements, an `arc-swap` dev dependency, and instructions for generating credentials, rotating them, and checking the certificate served by a fresh connection. Both examples close connections after the TLS handshake. The documentation explains session-resumption limits and how to use the same approach with Actix Web. No library API changes.

Related: #13 and https://github.com/actix/actix-web/issues/754.

## Validation

- `just all_crate_features='--features actix-tls/openssl,actix-tls/rustls-0_23' clippy`
- `cargo build -p actix-tls --example accept-openssl-reload --example accept-rustls-reload --features openssl,rustls-0_23`
- Nightly rustfmt checks for both examples and Prettier check for the example README.
- Live macOS checks for both examples: initial handshake, clients without SNI, retention during a mismatched certificate/key update, successful rotation, retention after an empty certificate file, and rejection of invalid startup credentials.

Cargo reports the existing unsupported `lints.cargo` manifest-key warning.
